### PR TITLE
fix: get rid of undeclared timezones in caldav ics files

### DIFF
--- a/calendar/lib/object.php
+++ b/calendar/lib/object.php
@@ -936,9 +936,11 @@ class OC_Calendar_Object{
 			$timezone = OC_Calendar_App::getTimezone();
 			$timezone = new DateTimeZone($timezone);
 			$start = new DateTime($from.' '.$fromtime, $timezone);
+			$start->setTimezone(new DateTimeZone('UTC'));
 			$end = new DateTime($to.' '.$totime, $timezone);
-			$vevent->setDateTime('DTSTART', $start, Sabre_VObject_Property_DateTime::LOCALTZ);
-			$vevent->setDateTime('DTEND', $end, Sabre_VObject_Property_DateTime::LOCALTZ);
+			$end->setTimezone(new DateTimeZone('UTC'));
+			$vevent->setDateTime('DTSTART', $start, Sabre_VObject_Property_DateTime::UTC);
+			$vevent->setDateTime('DTEND', $end, Sabre_VObject_Property_DateTime::UTC);
 		}
 		unset($vevent->DURATION);
 


### PR DESCRIPTION
This commit fixes .ics files generated by sabre. The calendar export feature already worked as expected, but I found the following two additional ways to generate .ics data:
- calendar app -> calendars icon -> CalDav-Link -> all the individual .ics files
- calendar app -> settings -> Read only iCalendar link(s)

Those files contained timeZoneIds without them being actually specified. So one solution would have been to include the time zone definitions. However, it seemed easier to simply convert DTSTART and DTEND to UTC instead of transporting the date time info in the user defined timezone.

So this patch converts the user provided date time info from the users timezone to UTC before setting them on the vevent object. When sabre writes the events or calendars, it doesn't need to write TZID fields and consequently there are no longer missing time zone definitions.

I validate the generated .ics files using http://icalvalid.cloudapp.net/, they all seem to be fine now.

However, somebody should review the change! I'm not familiar with ownCloud's code base, and I'm not sure if somewhere the event's start date/ end date is expected to be in the user's timezone!
