### PR TITLE
Fix redirect URL so it honours https servers

### DIFF
--- a/user_openid/user_openid.php
+++ b/user_openid/user_openid.php
@@ -36,12 +36,19 @@ class OC_USER_OPENID extends OC_User_Backend {
 	 * Check if the password is correct without logging in the user
 	 */
 	public function checkPassword( $uid, $password ) {
+		// Check whether request was made through HTTPS protocol
+		if (isset($_SERVER['HTTPS']) && strcasecmp("off", $_SERVER['HTTPS']) != 0) {
+			$schema = "https://";
+		}
+		else {
+			$schema = "http://";
+		}
 		// Get identity from user and redirect browser to OpenID Server
 		$openid = new SimpleOpenID();
 		$openid->SetIdentity($uid);
-		$openid->SetTrustRoot('http://' . OCP\Util::getServerHost());
+		$openid->SetTrustRoot($schema . OCP\Util::getServerHost());
 		if ($openid->GetOpenIDServer()) {
-			$openid->SetApprovedURL('http://' . OCP\Util::getServerHost() . OC::$WEBROOT);      // Send Response from OpenID server to this script
+			$openid->SetApprovedURL($schema . OCP\Util::getServerHost() . OC::$WEBROOT);      // Send Response from OpenID server to this script
 			$openid->Redirect();     // This will redirect user to OpenID Server
 			exit;
 		}else{
@@ -49,7 +56,7 @@ class OC_USER_OPENID extends OC_User_Backend {
 		}
 		exit;
 	}
-
+	
 	/**
 	 * find the user that can be authenticated with an openid identity
 	 */


### PR DESCRIPTION
When using openid logins to owncloud servers running https only the login breaks. Also bad policy to break a users chosen wish to use https 
