### PR TITLE
Calendar: use php functions to convert timezone

### DIFF
--- a/calendar/ajax/event/edit.form.php
+++ b/calendar/ajax/event/edit.form.php
@@ -28,12 +28,12 @@ $dtstart = $vevent->DTSTART;
 $dtend = OC_Calendar_Object::getDTEndFromVEvent($vevent);
 switch($dtstart->getDateType()) {
 	case Sabre_VObject_Property_DateTime::UTC:
-		$timeOffset = $_SESSION['timezone']*60;
-		$newDT      = $dtstart->getDateTime();
-		$newDT->add(new DateInterval("PT" . $timeOffset . "M"));
+		$timezone = new DateTimeZone(OC_Calendar_App::getTimezone());
+		$newDT    = $dtstart->getDateTime();
+		$newDT->setTimezone($timezone);
 		$dtstart->setDateTime($newDT);
-		$newDT      = $dtend->getDateTime();
-		$newDT->add(new DateInterval("PT" . $timeOffset . "M"));
+		$newDT    = $dtend->getDateTime();
+		$newDT->setTimezone($timezone);
 		$dtend->setDateTime($newDT);
 	case Sabre_VObject_Property_DateTime::LOCALTZ:
 	case Sabre_VObject_Property_DateTime::LOCAL:


### PR DESCRIPTION
Currently the codes calculates the new time with timezonediff*60.
This is working most of the times, but contains some bugs.

Atm i'm in UTC+02 (CEST), but if I edit a item from November, this is UTC+02 (CET).
The current function doesn't know that, and gives you a value UTC+02.

Therefor we just use the PHP functions to calculate the new time.
