### PR TITLE
Use CRUDS consts as defined in https://github.com/owncloud/core/pull/356

### DIFF
--- a/calendar/ajax/calendar/update.php
+++ b/calendar/ajax/calendar/update.php
@@ -45,7 +45,7 @@ $tmpl->assign('calendar', $calendar);
 $shared = false;
 if ($calendar['userid'] != OCP\User::getUser()) {
 	$sharedCalendar = OCP\Share::getItemSharedWithBySource('calendar', $calendarid);
-	if ($sharedCalendar && ($sharedCalendar['permissions'] & OCP\Share::PERMISSION_UPDATE)) {
+	if ($sharedCalendar && ($sharedCalendar['permissions'] & OCP\PERMISSION_UPDATE)) {
 		$shared = true;
 	}
 }

--- a/calendar/ajax/event/edit.form.php
+++ b/calendar/ajax/event/edit.form.php
@@ -209,9 +209,9 @@ $repeat_bymonth_options = OC_Calendar_App::getByMonthOptions();
 $repeat_byweekno_options = OC_Calendar_App::getByWeekNoOptions();
 $repeat_bymonthday_options = OC_Calendar_App::getByMonthDayOptions();
 
-if($permissions & OCP\Share::PERMISSION_UPDATE) {
+if($permissions & OCP\PERMISSION_UPDATE) {
 	$tmpl = new OCP\Template('calendar', 'part.editevent');
-} elseif($permissions & OCP\Share::PERMISSION_READ) {
+} elseif($permissions & OCP\PERMISSION_READ) {
 	$tmpl = new OCP\Template('calendar', 'part.showevent');
 }
 

--- a/calendar/ajax/event/new.form.php
+++ b/calendar/ajax/event/new.form.php
@@ -37,7 +37,7 @@ $calendar_options = array();
 foreach($calendars as $calendar) {
 	if($calendar['userid'] != OCP\User::getUser()) {
 		$sharedCalendar = OCP\Share::getItemSharedWithBySource('calendar', $calendar['id']);
-		if ($sharedCalendar && ($sharedCalendar['permissions'] & OCP\Share::PERMISSION_UPDATE)) {
+		if ($sharedCalendar && ($sharedCalendar['permissions'] & OCP\PERMISSION_UPDATE)) {
 			array_push($calendar_options, $calendar);
 		}
 	} else {

--- a/calendar/ajax/event/resize.php
+++ b/calendar/ajax/event/resize.php
@@ -12,7 +12,7 @@ OCP\JSON::callCheck();
 $id = $_POST['id'];
 
 $permissions = OC_Calendar_App::getPermissions($id, OC_Calendar_App::EVENT);
-if(!$permissions & OCP\Share::PERMISSION_UPDATE) {
+if(!$permissions & OCP\PERMISSION_UPDATE) {
 	OCP\JSON::error(array('message'=>'permission denied'));
 	exit;
 }

--- a/calendar/lib/app.php
+++ b/calendar/lib/app.php
@@ -296,9 +296,7 @@ class OC_Calendar_App{
 	 * @see OCP\Share
 	 */
 	public static function getPermissions($id, $type) {
-		 $permissions_all = OCP\Share::PERMISSION_CREATE
-				| OCP\Share::PERMISSION_READ | OCP\Share::PERMISSION_UPDATE
-				| OCP\Share::PERMISSION_DELETE | OCP\Share::PERMISSION_SHARE;
+		 $permissions_all = OCP\PERMISSION_ALL;
 
 		if($type == self::CALENDAR) {
 			$calendar = self::getCalendar($id, false, false);

--- a/calendar/lib/calendar.php
+++ b/calendar/lib/calendar.php
@@ -47,9 +47,9 @@ class OC_Calendar_Calendar{
 
 		$calendars = array();
 		while( $row = $result->fetchRow()) {
-			$row['permissions'] = OCP\Share::PERMISSION_CREATE
-				| OCP\Share::PERMISSION_READ | OCP\Share::PERMISSION_UPDATE
-				| OCP\Share::PERMISSION_DELETE | OCP\Share::PERMISSION_SHARE;
+			$row['permissions'] = OCP\PERMISSION_CREATE
+				| OCP\PERMISSION_READ | OCP\PERMISSION_UPDATE
+				| OCP\PERMISSION_DELETE | OCP\PERMISSION_SHARE;
 			$calendars[] = $row;
 		}
 		$calendars = array_merge($calendars, OCP\Share::getItemsSharedWith('calendar', OC_Share_Backend_Calendar::FORMAT_CALENDAR));
@@ -79,14 +79,12 @@ class OC_Calendar_Calendar{
 		$row = $result->fetchRow();
 		if($row['userid'] != OCP\USER::getUser() && !OC_Group::inGroup(OCP\User::getUser(), 'admin')) {
 			$sharedCalendar = OCP\Share::getItemSharedWithBySource('calendar', $id);
-			if (!$sharedCalendar || !($sharedCalendar['permissions'] & OCP\Share::PERMISSION_READ)) {
+			if (!$sharedCalendar || !($sharedCalendar['permissions'] & OCP\PERMISSION_READ)) {
 				return $row; // I have to return the row so e.g. OC_Calendar_Object::getowner() works.
 			}
 			$row['permissions'] = $sharedCalendar['permissions'];
 		} else {
-			$row['permissions'] = OCP\Share::PERMISSION_CREATE
-				| OCP\Share::PERMISSION_READ | OCP\Share::PERMISSION_UPDATE
-				| OCP\Share::PERMISSION_DELETE | OCP\Share::PERMISSION_SHARE;
+			$row['permissions'] = OCP\PERMISSION_ALL;
 		}
 		return $row;
 	}
@@ -159,7 +157,7 @@ class OC_Calendar_Calendar{
 		$calendar = self::find($id);
 		if ($calendar['userid'] != OCP\User::getUser() && !OC_Group::inGroup(OCP\User::getUser(), 'admin')) {
 			$sharedCalendar = OCP\Share::getItemSharedWithBySource('calendar', $id);
-			if (!$sharedCalendar || !($sharedCalendar['permissions'] & OCP\Share::PERMISSION_UPDATE)) {
+			if (!$sharedCalendar || !($sharedCalendar['permissions'] & OCP\PERMISSION_UPDATE)) {
 				throw new Exception(
 					OC_Calendar_App::$l10n->t(
 						'You do not have the permissions to update this calendar.'
@@ -192,7 +190,7 @@ class OC_Calendar_Calendar{
 		$calendar = self::find($id);
 		if ($calendar['userid'] != OCP\User::getUser()) {
 			$sharedCalendar = OCP\Share::getItemSharedWithBySource('calendar', $id);
-			if (!$sharedCalendar || !($sharedCalendar['permissions'] & OCP\Share::PERMISSION_UPDATE)) {
+			if (!$sharedCalendar || !($sharedCalendar['permissions'] & OCP\PERMISSION_UPDATE)) {
 				throw new Exception(
 					OC_Calendar_App::$l10n->t(
 						'You do not have the permissions to update this calendar.'
@@ -227,7 +225,7 @@ class OC_Calendar_Calendar{
 		$calendar = self::find($id);
 		if ($calendar['userid'] != OCP\User::getUser() && !OC_Group::inGroup(OCP\User::getUser(), 'admin')) {
 			$sharedCalendar = OCP\Share::getItemSharedWithBySource('calendar', $id);
-			if (!$sharedCalendar || !($sharedCalendar['permissions'] & OCP\Share::PERMISSION_DELETE)) {
+			if (!$sharedCalendar || !($sharedCalendar['permissions'] & OCP\PERMISSION_DELETE)) {
 				throw new Exception(
 					OC_Calendar_App::$l10n->t(
 						'You do not have the permissions to delete this calendar.'
@@ -261,7 +259,7 @@ class OC_Calendar_Calendar{
 		$calendar = self::find($id1);
 		if ($calendar['userid'] != OCP\User::getUser() && !OC_Group::inGroup(OCP\User::getUser(), 'admin')) {
 			$sharedCalendar = OCP\Share::getItemSharedWithBySource('calendar', $id1);
-			if (!$sharedCalendar || !($sharedCalendar['permissions'] & OCP\Share::PERMISSION_UPDATE)) {
+			if (!$sharedCalendar || !($sharedCalendar['permissions'] & OCP\PERMISSION_UPDATE)) {
 				throw new Exception(
 					OC_Calendar_App::$l10n->t(
 						'You do not have the permissions to add to this calendar.'

--- a/calendar/lib/object.php
+++ b/calendar/lib/object.php
@@ -116,7 +116,7 @@ class OC_Calendar_Object{
 		$calendar = OC_Calendar_Calendar::find($id);
 		if ($calendar['userid'] != OCP\User::getUser()) {
 			$sharedCalendar = OCP\Share::getItemSharedWithBySource('calendar', $id);
-			if (!$sharedCalendar || !($sharedCalendar['permissions'] & OCP\Share::PERMISSION_CREATE)) {
+			if (!$sharedCalendar || !($sharedCalendar['permissions'] & OCP\PERMISSION_CREATE)) {
 				throw new Exception(
 					OC_Calendar_App::$l10n->t(
 						'You do not have the permissions to add events to this calendar.'
@@ -155,7 +155,7 @@ class OC_Calendar_Object{
 		$calendar = OC_Calendar_Calendar::find($id);
 		if ($calendar['userid'] != OCP\User::getUser()) {
 			$sharedCalendar = OCP\Share::getItemSharedWithBySource('calendar', $id);
-			if (!$sharedCalendar || !($sharedCalendar['permissions'] & OCP\Share::PERMISSION_CREATE)) {
+			if (!$sharedCalendar || !($sharedCalendar['permissions'] & OCP\PERMISSION_CREATE)) {
 				throw new Sabre_DAV_Exception_Forbidden(
 					OC_Calendar_App::$l10n->t(
 						'You do not have the permissions to add events to this calendar.'
@@ -187,7 +187,7 @@ class OC_Calendar_Object{
 		$calendar = OC_Calendar_Calendar::find($oldobject['calendarid']);
 		if ($calendar['userid'] != OCP\User::getUser()) {
 			$sharedCalendar = OCP\Share::getItemSharedWithBySource('calendar', $id);
-			if (!$sharedCalendar || !($sharedCalendar['permissions'] & OCP\Share::PERMISSION_UPDATE)) {
+			if (!$sharedCalendar || !($sharedCalendar['permissions'] & OCP\PERMISSION_UPDATE)) {
 				throw new Exception(
 					OC_Calendar_App::$l10n->t(
 						'You do not have the permissions to edit this event.'
@@ -221,7 +221,7 @@ class OC_Calendar_Object{
 		$calendar = OC_Calendar_Calendar::find($cid);
 		if ($calendar['userid'] != OCP\User::getUser()) {
 			$sharedCalendar = OCP\Share::getItemSharedWithBySource('calendar', $cid);
-			if (!$sharedCalendar || !($sharedCalendar['permissions'] & OCP\Share::PERMISSION_UPDATE)) {
+			if (!$sharedCalendar || !($sharedCalendar['permissions'] & OCP\PERMISSION_UPDATE)) {
 				throw new Sabre_DAV_Exception_Forbidden(
 					OC_Calendar_App::$l10n->t(
 						'You do not have the permissions to edit this event.'
@@ -251,7 +251,7 @@ class OC_Calendar_Object{
 		$calendar = OC_Calendar_Calendar::find($oldobject['calendarid']);
 		if ($calendar['userid'] != OCP\User::getUser()) {
 			$sharedCalendar = OCP\Share::getItemSharedWithBySource('calendar', $id);
-			if (!$sharedCalendar || !($sharedCalendar['permissions'] & OCP\Share::PERMISSION_DELETE)) {
+			if (!$sharedCalendar || !($sharedCalendar['permissions'] & OCP\PERMISSION_DELETE)) {
 				throw new Exception(
 					OC_Calendar_App::$l10n->t(
 						'You do not have the permissions to delete this event.'
@@ -264,7 +264,7 @@ class OC_Calendar_Object{
 		OC_Calendar_Calendar::touchCalendar($oldobject['calendarid']);
 
 		OCP\Share::unshareAll('event', $id);
-		
+
 		OCP\Util::emitHook('OC_Calendar', 'deleteEvent', $id);
 
 		return true;
@@ -281,7 +281,7 @@ class OC_Calendar_Object{
 		$calendar = OC_Calendar_Calendar::find($cid);
 		if ($calendar['userid'] != OCP\User::getUser()) {
 			$sharedCalendar = OCP\Share::getItemSharedWithBySource('calendar', $cid);
-			if (!$sharedCalendar || !($sharedCalendar['permissions'] & OCP\Share::PERMISSION_DELETE)) {
+			if (!$sharedCalendar || !($sharedCalendar['permissions'] & OCP\PERMISSION_DELETE)) {
 				throw new Sabre_DAV_Exception_Forbidden(
 					OC_Calendar_App::$l10n->t(
 						'You do not have the permissions to delete this event.'
@@ -301,7 +301,7 @@ class OC_Calendar_Object{
 		$calendar = OC_Calendar_Calendar::find($calendarid);
 		if ($calendar['userid'] != OCP\User::getUser()) {
 			$sharedCalendar = OCP\Share::getItemSharedWithBySource('calendar', $id);
-			if (!$sharedCalendar || !($sharedCalendar['permissions'] & OCP\Share::PERMISSION_DELETE)) {
+			if (!$sharedCalendar || !($sharedCalendar['permissions'] & OCP\PERMISSION_DELETE)) {
 				throw new Exception(
 					OC_Calendar_App::$l10n->t(
 						'You do not have the permissions to add events to this calendar.'

--- a/calendar/lib/sabre/calendar.php
+++ b/calendar/lib/sabre/calendar.php
@@ -48,10 +48,10 @@ class OC_Connector_Sabre_CalDAV_Calendar extends Sabre_CalDAV_Calendar {
 
 		if($uid != OCP\USER::getUser()) {
 			$sharedCalendar = OCP\Share::getItemSharedWithBySource('calendar', $this->calendarInfo['id']);
-			if ($sharedCalendar && ($sharedCalendar['permissions'] & OCP\Share::PERMISSION_READ)) {
+			if ($sharedCalendar && ($sharedCalendar['permissions'] & OCP\PERMISSION_READ)) {
 				$readprincipal = 'principals/' . OCP\USER::getUser();
 			}
-			if ($sharedCalendar && ($sharedCalendar['permissions'] & OCP\Share::PERMISSION_UPDATE)) {
+			if ($sharedCalendar && ($sharedCalendar['permissions'] & OCP\PERMISSION_UPDATE)) {
 				$writeprincipal = 'principals/' . OCP\USER::getUser();
 			}
 		}

--- a/calendar/lib/sabre/object.php
+++ b/calendar/lib/sabre/object.php
@@ -46,10 +46,10 @@ class OC_Connector_Sabre_CalDAV_CalendarObject extends Sabre_CalDAV_CalendarObje
 
 		if($uid != OCP\USER::getUser()) {
 			$sharedCalendar = OCP\Share::getItemSharedWithBySource('calendar', $this->calendarInfo['id']);
-			if ($sharedCalendar && ($sharedCalendar['permissions'] & OCP\Share::PERMISSION_READ)) {
+			if ($sharedCalendar && ($sharedCalendar['permissions'] & OCP\PERMISSION_READ)) {
 				$readprincipal = 'principals/' . OCP\USER::getUser();
 			}
-			if ($sharedCalendar && ($sharedCalendar['permissions'] & OCP\Share::PERMISSION_UPDATE)) {
+			if ($sharedCalendar && ($sharedCalendar['permissions'] & OCP\PERMISSION_UPDATE)) {
 				$writeprincipal = 'principals/' . OCP\USER::getUser();
 			}
 		}

--- a/calendar/templates/part.choosecalendar.rowfields.php
+++ b/calendar/templates/part.choosecalendar.rowfields.php
@@ -7,7 +7,7 @@
   <label for="active_<?php echo $_['calendar']['id'] ?>"><?php echo $_['calendar']['displayname'] ?></label>
 </td>
 <td width="20px">
-  <?php if($_['calendar']['permissions'] & OCP\Share::PERMISSION_SHARE) { ?>
+  <?php if($_['calendar']['permissions'] & OCP\PERMISSION_SHARE) { ?>
   <a href="#" class="share" data-item-type="calendar" data-item="<?php echo $_['calendar']['id']; ?>"
 	data-possible-permissions="<?php echo $_['calendar']['permissions'] ?>"
 	title="<?php echo $l->t('Share Calendar') ?>" class="action"><img class="svg action" src="<?php echo (!$_['shared']) ? OCP\Util::imagePath('core', 'actions/share.svg') : OCP\Util::imagePath('core', 'actions/shared.svg') ?>"></a>
@@ -27,12 +27,12 @@ if($_['calendar']['userid'] == OCP\USER::getUser()){
   <a href="<?php echo OCP\Util::linkTo('calendar', 'export.php') . '?calid=' . $_['calendar']['id'] ?>" title="<?php echo $l->t('Download') ?>" class="action"><img class="svg action" src="<?php echo OCP\Util::imagePath('core', 'actions/download.svg') ?>"></a>
 </td>
 <td width="20px">
-  <?php if($_['calendar']['permissions'] & OCP\Share::PERMISSION_UPDATE) { ?>
+  <?php if($_['calendar']['permissions'] & OCP\PERMISSION_UPDATE) { ?>
   <a href="#" onclick="Calendar.UI.Calendar.edit(this, <?php echo $_['calendar']['id'] ?>);" title="<?php echo $l->t('Edit') ?>" class="action"><img class="svg action" src="<?php echo OCP\Util::imagePath('core', 'actions/rename.svg') ?>"></a>
   <?php } ?>
 </td>
 <td width="20px">
-  <?php if($_['calendar']['permissions'] & OCP\Share::PERMISSION_DELETE) { ?>
+  <?php if($_['calendar']['permissions'] & OCP\PERMISSION_DELETE) { ?>
   <a href="#" onclick="Calendar.UI.Calendar.deleteCalendar(<?php echo $_['calendar']['id'] ?>);" title="<?php echo $l->t('Delete') ?>" class="action"><img class="svg action" src="<?php echo OCP\Util::imagePath('core', 'actions/delete.svg') ?>"></a>
   <?php } ?>
 </td>

--- a/calendar/templates/part.eventform.php
+++ b/calendar/templates/part.eventform.php
@@ -9,7 +9,7 @@ echo 'Calendar.UI.Share.idtype = "event";' . "\n" . 'Calendar.UI.Share.currentid
 	<li><a href="#tabs-2"><?php echo $l->t('Repeating'); ?></a></li>
 	<!--<li><a href="#tabs-3"><?php echo $l->t('Alarm'); ?></a></li>
 	<li><a href="#tabs-4"><?php echo $l->t('Attendees'); ?></a></li>-->
-	<?php if($_['eventid'] != 'new' && $_['permissions'] & OCP\Share::PERMISSION_SHARE) { ?>
+	<?php if($_['eventid'] != 'new' && $_['permissions'] & OCP\PERMISSION_SHARE) { ?>
 	<li><a href="#tabs-5"><?php echo $l->t('Share'); ?></a></li>
 	<?php } ?>
 </ul>
@@ -244,7 +244,7 @@ echo 'Calendar.UI.Share.idtype = "event";' . "\n" . 'Calendar.UI.Share.currentid
 </div>
 <!--<div id="tabs-3">//Alarm</div>
 <div id="tabs-4">//Attendees</div>-->
-<?php if($_['eventid'] != 'new' && $_['permissions'] & OCP\Share::PERMISSION_SHARE) { ?>
+<?php if($_['eventid'] != 'new' && $_['permissions'] & OCP\PERMISSION_SHARE) { ?>
 <div id="tabs-5">
 	<?php if($_['eventid'] != 'new') { echo $this->inc('part.share'); } ?>
 </div>

--- a/calendar/templates/part.share.php
+++ b/calendar/templates/part.share.php
@@ -37,11 +37,11 @@ if(is_array($sharedwithByEvent)) {
 		data-share-type="<?php echo $sharee['share_type']; ?>">
 		<?php echo $sharee['share_with'] . ' (' . ($sharee['share_type'] == OCP\Share::SHARE_TYPE_USER ? 'user' : 'group'). ')'; ?>
 		<span class="shareactions">
-			<input class="update" type="checkbox" <?php echo ($sharee['permissions'] & OCP\Share::PERMISSION_UPDATE?'checked="checked"':'')?>
+			<input class="update" type="checkbox" <?php echo ($sharee['permissions'] & OCP\PERMISSION_UPDATE?'checked="checked"':'')?>
 				title="<?php echo $l->t('Editable'); ?>">
-			<input class="share" type="checkbox" <?php echo ($sharee['permissions'] & OCP\Share::PERMISSION_SHARE?'checked="checked"':'')?>
+			<input class="share" type="checkbox" <?php echo ($sharee['permissions'] & OCP\PERMISSION_SHARE?'checked="checked"':'')?>
 				title="<?php echo $l->t('Shareable'); ?>">
-			<input class="delete" type="checkbox" <?php echo ($sharee['permissions'] & OCP\Share::PERMISSION_DELETE?'checked="checked"':'')?>
+			<input class="delete" type="checkbox" <?php echo ($sharee['permissions'] & OCP\PERMISSION_DELETE?'checked="checked"':'')?>
 				title="<?php echo $l->t('Deletable'); ?>">
 			<img src="<?php echo OCP\Util::imagePath('core', 'actions/delete.svg'); ?>" class="svg action delete"
 				title="<?php echo $l->t('Unshare'); ?>">
@@ -63,11 +63,11 @@ if(is_array($sharedwithByEvent)) {
 		data-share-type="<?php echo $sharee['share_type']; ?>">
 		<?php echo $sharee['share_with'] . ' (' . ($sharee['share_type'] == OCP\Share::SHARE_TYPE_USER ? 'user' : 'group'). ')'; ?>
 		<span class="shareactions">
-			<input class="update" type="checkbox" <?php echo ($sharee['permissions'] & OCP\Share::PERMISSION_UPDATE?'checked="checked"':'')?>
+			<input class="update" type="checkbox" <?php echo ($sharee['permissions'] & OCP\PERMISSION_UPDATE?'checked="checked"':'')?>
 				title="<?php echo $l->t('Editable'); ?>">
-			<input class="share" type="checkbox" <?php echo ($sharee['permissions'] & OCP\Share::PERMISSION_SHARE?'checked="checked"':'')?>
+			<input class="share" type="checkbox" <?php echo ($sharee['permissions'] & OCP\PERMISSION_SHARE?'checked="checked"':'')?>
 				title="<?php echo $l->t('Shareable'); ?>">
-			<input class="delete" type="checkbox" <?php echo ($sharee['permissions'] & OCP\Share::PERMISSION_DELETE?'checked="checked"':'')?>
+			<input class="delete" type="checkbox" <?php echo ($sharee['permissions'] & OCP\PERMISSION_DELETE?'checked="checked"':'')?>
 				title="<?php echo $l->t('Deletable'); ?>">
 			<img src="<?php echo OCP\Util::imagePath('core', 'actions/delete.svg'); ?>" class="svg action delete"
 				title="<?php echo $l->t('Unshare'); ?>">

--- a/contacts/ajax/contact/details.php
+++ b/contacts/ajax/contact/details.php
@@ -55,9 +55,7 @@ if(!$lastmodified) {
 	$lastmodified = new DateTime();
 }
 
-$permissions = OCP\Share::PERMISSION_CREATE | OCP\Share::PERMISSION_READ 
-	| OCP\Share::PERMISSION_UPDATE | OCP\Share::PERMISSION_DELETE 
-	| OCP\Share::PERMISSION_SHARE;
+$permissions = OCP\PERMISSION_ALL;
 $addressbook = OC_Contacts_Addressbook::find($card['addressbookid']);
 if ($addressbook['userid'] != OCP\User::getUser()) {
 	$sharedAddressbook = OCP\Share::getItemSharedWithBySource('addressbook', $card['addressbookid']);

--- a/contacts/lib/addressbook.php
+++ b/contacts/lib/addressbook.php
@@ -62,9 +62,7 @@ class OC_Contacts_Addressbook {
 
 		$addressbooks = array();
 		while( $row = $result->fetchRow()) {
-			$row['permissions'] = OCP\Share::PERMISSION_CREATE
-				| OCP\Share::PERMISSION_READ | OCP\Share::PERMISSION_UPDATE
-				| OCP\Share::PERMISSION_DELETE | OCP\Share::PERMISSION_SHARE;
+			$row['permissions'] = OCP\PERMISSION_ALL;
 			$addressbooks[] = $row;
 		}
 		$addressbooks = array_merge($addressbooks, OCP\Share::getItemsSharedWith('addressbook', OC_Share_Backend_Addressbook::FORMAT_ADDRESSBOOKS));
@@ -132,7 +130,7 @@ class OC_Contacts_Addressbook {
 		$row = $result->fetchRow();
 		if($row['userid'] != OCP\USER::getUser() && !OC_Group::inGroup(OCP\User::getUser(), 'admin')) {
 			$sharedAddressbook = OCP\Share::getItemSharedWithBySource('addressbook', $id);
-			if (!$sharedAddressbook || !($sharedAddressbook['permissions'] & OCP\Share::PERMISSION_READ)) {
+			if (!$sharedAddressbook || !($sharedAddressbook['permissions'] & OCP\PERMISSION_READ)) {
 				throw new Exception(
 					OC_Contacts_App::$l10n->t(
 						'You do not have the permissions to read this addressbook.'
@@ -141,9 +139,7 @@ class OC_Contacts_Addressbook {
 			}
 			$row['permissions'] = $sharedAddressbook['permissions'];
 		} else {
-			$row['permissions'] = OCP\Share::PERMISSION_CREATE
-				| OCP\Share::PERMISSION_READ | OCP\Share::PERMISSION_UPDATE
-				| OCP\Share::PERMISSION_DELETE | OCP\Share::PERMISSION_SHARE;
+			$row['permissions'] = OCP\PERMISSION_ALL;
 		}
 		return $row;
 	}
@@ -233,7 +229,7 @@ class OC_Contacts_Addressbook {
 		$addressbook = self::find($id);
 		if ($addressbook['userid'] != OCP\User::getUser() && !OC_Group::inGroup(OCP\User::getUser(), 'admin')) {
 			$sharedAddressbook = OCP\Share::getItemSharedWithBySource('addressbook', $id);
-			if (!$sharedAddressbook || !($sharedAddressbook['permissions'] & OCP\Share::PERMISSION_UPDATE)) {
+			if (!$sharedAddressbook || !($sharedAddressbook['permissions'] & OCP\PERMISSION_UPDATE)) {
 				throw new Exception(
 					OC_Contacts_App::$l10n->t(
 						'You do not have the permissions to update this addressbook.'
@@ -309,7 +305,7 @@ class OC_Contacts_Addressbook {
 		$addressbook = self::find($id);
 		if ($addressbook['userid'] != OCP\User::getUser() && !OC_Group::inGroup(OCP\User::getUser(), 'admin')) {
 			$sharedAddressbook = OCP\Share::getItemSharedWithBySource('addressbook', $id);
-			if (!$sharedAddressbook || !($sharedAddressbook['permissions'] & OCP\Share::PERMISSION_DELETE)) {
+			if (!$sharedAddressbook || !($sharedAddressbook['permissions'] & OCP\PERMISSION_DELETE)) {
 				throw new Exception(
 					OC_Contacts_App::$l10n->t(
 						'You do not have the permissions to delete this addressbook.'

--- a/contacts/lib/sabre/addressbook.php
+++ b/contacts/lib/sabre/addressbook.php
@@ -72,10 +72,10 @@ class OC_Connector_Sabre_CardDAV_AddressBook extends Sabre_CardDAV_AddressBook {
 
 		if($uid != OCP\USER::getUser()) {
 			$sharedAddressbook = OCP\Share::getItemSharedWithBySource('addressbook', $this->addressBookInfo['id']);
-			if ($sharedAddressbook && ($sharedAddressbook['permissions'] & OCP\Share::PERMISSION_READ)) {
+			if ($sharedAddressbook && ($sharedAddressbook['permissions'] & OCP\PERMISSION_READ)) {
 				$readprincipal = 'principals/' . OCP\USER::getUser();
 			}
-			if ($sharedAddressbook && ($sharedAddressbook['permissions'] & OCP\Share::PERMISSION_UPDATE)) {
+			if ($sharedAddressbook && ($sharedAddressbook['permissions'] & OCP\PERMISSION_UPDATE)) {
 				$writeprincipal = 'principals/' . OCP\USER::getUser();
 			}
 		}

--- a/contacts/lib/sabre/card.php
+++ b/contacts/lib/sabre/card.php
@@ -67,10 +67,10 @@ class OC_Connector_Sabre_CardDAV_Card extends Sabre_CardDAV_Card {
 
 		if($uid != OCP\USER::getUser()) {
 			$sharedAddressbook = OCP\Share::getItemSharedWithBySource('addressbook', $this->addressBookInfo['id']);
-			if ($sharedAddressbook && ($sharedAddressbook['permissions'] & OCP\Share::PERMISSION_READ)) {
+			if ($sharedAddressbook && ($sharedAddressbook['permissions'] & OCP\PERMISSION_READ)) {
 				$readprincipal = 'principals/' . OCP\USER::getUser();
 			}
-			if ($sharedAddressbook && ($sharedAddressbook['permissions'] & OCP\Share::PERMISSION_UPDATE)) {
+			if ($sharedAddressbook && ($sharedAddressbook['permissions'] & OCP\PERMISSION_UPDATE)) {
 				$writeprincipal = 'principals/' . OCP\USER::getUser();
 			}
 		}

--- a/contacts/lib/vcard.php
+++ b/contacts/lib/vcard.php
@@ -295,7 +295,7 @@ class OC_Contacts_VCard {
 		$addressbook = OC_Contacts_Addressbook::find($aid);
 		if ($addressbook['userid'] != OCP\User::getUser()) {
 			$sharedAddressbook = OCP\Share::getItemSharedWithBySource('addressbook', $aid);
-			if (!$sharedAddressbook || !($sharedAddressbook['permissions'] & OCP\Share::PERMISSION_CREATE)) {
+			if (!$sharedAddressbook || !($sharedAddressbook['permissions'] & OCP\PERMISSION_CREATE)) {
 				throw new Exception(
 					OC_Contacts_App::$l10n->t(
 						'You do not have the permissions to add contacts to this addressbook.'
@@ -372,7 +372,7 @@ class OC_Contacts_VCard {
 				$addressbook = OC_Contacts_Addressbook::find($oldcard['addressbookid']);
 				if ($addressbook['userid'] != OCP\User::getUser()) {
 					$sharedContact = OCP\Share::getItemSharedWithBySource('contact', $object[0], OCP\Share::FORMAT_NONE, null, true);
-					if (!$sharedContact || !($sharedContact['permissions'] & OCP\Share::PERMISSION_UPDATE)) {
+					if (!$sharedContact || !($sharedContact['permissions'] & OCP\PERMISSION_UPDATE)) {
 						return false;
 					}
 				}
@@ -424,7 +424,7 @@ class OC_Contacts_VCard {
 				$contact_permissions = $sharedEvent['permissions'];
 			}
 			$permissions = max($addressbook_permissions, $contact_permissions);
-			if (!($permissions & OCP\Share::PERMISSION_UPDATE)) {
+			if (!($permissions & OCP\PERMISSION_UPDATE)) {
 				throw new Exception(
 					OC_Contacts_App::$l10n->t(
 						'You do not have the permissions to edit this contact.'
@@ -526,7 +526,7 @@ class OC_Contacts_VCard {
 				$contact_permissions = $sharedEvent['permissions'];
 			}
 			$permissions = max($addressbook_permissions, $contact_permissions);
-			if (!($permissions & OCP\Share::PERMISSION_DELETE)) {
+			if (!($permissions & OCP\PERMISSION_DELETE)) {
 				throw new Exception(
 					OC_Contacts_App::$l10n->t(
 						'You do not have the permissions to delete this contact.'
@@ -572,7 +572,7 @@ class OC_Contacts_VCard {
 				return false;
 			}
 			$sharedContact = OCP\Share::getItemSharedWithBySource('contact', $id, OCP\Share::FORMAT_NONE, null, true);
-			if (!$sharedContact || !($sharedContact['permissions'] & OCP\Share::PERMISSION_DELETE)) {
+			if (!$sharedContact || !($sharedContact['permissions'] & OCP\PERMISSION_DELETE)) {
 				return false;
 			}
 		}
@@ -733,7 +733,7 @@ class OC_Contacts_VCard {
 		$addressbook = OC_Contacts_Addressbook::find($aid);
 		if ($addressbook['userid'] != OCP\User::getUser()) {
 			$sharedAddressbook = OCP\Share::getItemSharedWithBySource('addressbook', $aid);
-			if (!$sharedAddressbook || !($sharedAddressbook['permissions'] & OCP\Share::PERMISSION_CREATE)) {
+			if (!$sharedAddressbook || !($sharedAddressbook['permissions'] & OCP\PERMISSION_CREATE)) {
 				return false;
 			}
 		}
@@ -746,7 +746,7 @@ class OC_Contacts_VCard {
 				$oldAddressbook = OC_Contacts_Addressbook::find($card['addressbookid']);
 				if ($oldAddressbook['userid'] != OCP\User::getUser()) {
 					$sharedContact = OCP\Share::getItemSharedWithBySource('contact', $cardId, OCP\Share::FORMAT_NONE, null, true);
-					if (!$sharedContact || !($sharedContact['permissions'] & OCP\Share::PERMISSION_DELETE)) {
+					if (!$sharedContact || !($sharedContact['permissions'] & OCP\PERMISSION_DELETE)) {
 						unset($id[$index]);
 					}
 				}
@@ -776,7 +776,7 @@ class OC_Contacts_VCard {
 				$oldAddressbook = OC_Contacts_Addressbook::find($card['addressbookid']);
 				if ($oldAddressbook['userid'] != OCP\User::getUser()) {
 					$sharedContact = OCP\Share::getItemSharedWithBySource('contact', $id, OCP\Share::FORMAT_NONE, null, true);
-					if (!$sharedContact || !($sharedContact['permissions'] & OCP\Share::PERMISSION_DELETE)) {
+					if (!$sharedContact || !($sharedContact['permissions'] & OCP\PERMISSION_DELETE)) {
 						return false;
 					}
 				}

--- a/contacts/templates/settings.php
+++ b/contacts/templates/settings.php
@@ -15,7 +15,7 @@
 				data-owner="<?php echo $addressbook['userid'] ?>"
 				>
 				<td class="active">
-					<?php if($addressbook['permissions'] & OCP\Share::PERMISSION_UPDATE) { ?>
+					<?php if($addressbook['permissions'] & OCP\PERMISSION_UPDATE) { ?>
 					<input type="checkbox" <?php echo (($addressbook['active']) == '1' ? ' checked="checked"' : ''); ?> />
 					<?php } ?>
 				</td>
@@ -28,7 +28,7 @@
 					<a class="svg action cloud" title="<?php echo $l->t('Show read-only VCF link'); ?>"></a>
 				</td>
 				<td class="action">
-					<?php if($addressbook['permissions'] & OCP\Share::PERMISSION_SHARE) { ?>
+					<?php if($addressbook['permissions'] & OCP\PERMISSION_SHARE) { ?>
 					<a class="svg action share" data-item-type="addressbook"
 						data-item="<?php echo $addressbook['id'] ?>"
 						data-possible-permissions="<?php echo $addressbook['permissions'] ?>"
@@ -40,12 +40,12 @@
 						href="<?php echo OCP\Util::linkToAbsolute('contacts', 'export.php'); ?>?bookid=<?php echo $addressbook['id'] ?>"></a>
 				</td>
 				<td class="action">
-					<?php if($addressbook['permissions'] & OCP\Share::PERMISSION_UPDATE) { ?>
+					<?php if($addressbook['permissions'] & OCP\PERMISSION_UPDATE) { ?>
 					<a class="svg action edit" title="<?php echo $l->t("Edit"); ?>"></a>
 					<?php } ?>
 				</td>
 				<td class="action">
-					<?php if($addressbook['permissions'] & OCP\Share::PERMISSION_DELETE) { ?>
+					<?php if($addressbook['permissions'] & OCP\PERMISSION_DELETE) { ?>
 					<a class="svg action delete" title="<?php echo $l->t("Delete"); ?>"></a>
 					<?php } ?>
 				</td>

--- a/news/templates/part.items.php
+++ b/news/templates/part.items.php
@@ -38,7 +38,7 @@ foreach($items as $item) {
 		} else {
 			$feedTitle = '';
 		}
-		
+
 		if(($item->getAuthor() !== null) && (trim($item->getAuthor()) !== '')) {
 			$author = $l->t('by') . ' ' . htmlspecialchars($item->getAuthor(), ENT_QUOTES, 'UTF-8');
 		} else {
@@ -53,12 +53,12 @@ foreach($items as $item) {
 
 		echo '<div class="bottom_utils">';
 			echo '<ul class="secondary_item_utils">';
-				echo '<li class="share_link"><a class="share" data-item-type="news_item" data-item="' . $item->getId() . '" title="' . $l->t('Share') . 
-		      '" data-possible-permissions="' . (OCP\Share::PERMISSION_READ | OCP\Share::PERMISSION_SHARE) . '" href="#">' . $l->t('Share') . '</a></li>';				
+				echo '<li class="share_link"><a class="share" data-item-type="news_item" data-item="' . $item->getId() . '" title="' . $l->t('Share') .
+		      '" data-possible-permissions="' . (OCP\PERMISSION_READ | OCP\PERMISSION_SHARE) . '" href="#">' . $l->t('Share') . '</a></li>';
 				echo '<li class="keep_unread">' . $l->t('Keep unread') . '<input type="checkbox" /></li>';
 			echo '</ul>';
 		echo '</div>';
-		
+
 
 	echo '</li>';
 

--- a/news/templates/part.shared.php
+++ b/news/templates/part.shared.php
@@ -39,7 +39,7 @@ foreach($items as $item) {
 		} else {
 			$feedTitle = '';
 		}
-		
+
 		if(($item->getAuthor() !== null) && (trim($item->getAuthor()) !== '')) {
 			$author = $l->t('by') . ' ' . htmlspecialchars($item->getAuthor(), ENT_QUOTES, 'UTF-8');
 		} else {
@@ -52,15 +52,15 @@ foreach($items as $item) {
 
 		echo '<div class="body">' . $item->getBody() . '</div>';
 
-		echo '<div><a class="share" data-item-type="news_item" data-item="' . $item->getId() . '" title="' . $l->t('Share') . 
-		      '" data-possible-permissions="' . (OCP\Share::PERMISSION_READ | OCP\Share::PERMISSION_SHARE) . '"/></div>';
-		
+		echo '<div><a class="share" data-item-type="news_item" data-item="' . $item->getId() . '" title="' . $l->t('Share') .
+		      '" data-possible-permissions="' . (OCP\PERMISSION_READ | OCP\PERMISSION_SHARE) . '"/></div>';
+
 		echo '<div class="bottom_utils">';
-			echo '<ul class="secondary_item_utils">';				
+			echo '<ul class="secondary_item_utils">';
 				echo '<li class="keep_unread">' . $l->t('Keep unread') . '<input type="checkbox" /></li>';
 			echo '</ul>';
 		echo '</div>';
-		
+
 
 	echo '</li>';
 


### PR DESCRIPTION
Updated the apps to use OCP\PERMISSION_\* instead of OCP\Share::PERMISSION_*

Corresponds to https://github.com/owncloud/core/pull/356
