### PR TITLE
Calendar: Encode event title and desc in javascript to avoid double encoding

### DIFF
--- a/calendar/ajax/events.php
+++ b/calendar/ajax/events.php
@@ -27,4 +27,4 @@ $output = array();
 foreach($events as $event) {
 	$output = array_merge($output, OC_Calendar_App::generateEventOutput($event, $start, $end));
 }
-OCP\JSON::encodedPrint(OCP\Util::sanitizeHTML($output));
+OCP\JSON::encodedPrint($output);

--- a/calendar/js/calendar.js
+++ b/calendar/js/calendar.js
@@ -246,10 +246,10 @@ Calendar={
 				// Tue 18 October 2011 08:00 - 16:00
 			}
 			var html =
-				'<div class="summary">' + event.title + '</div>' +
+				'<div class="summary">' + escapeHTML(event.title) + '</div>' +
 				'<div class="timespan">' + timespan + '</div>';
 			if (event.description){
-				html += '<div class="description">' + event.description + '</div>';
+				html += '<div class="description">' + escapeHTML(event.description) + '</div>';
 			}
 			return html;
 		},
@@ -800,7 +800,7 @@ function ListView(element, calendar) {
 			' class="' + classes.join(' ') + '"' +
 			'>' +
 			'<span class="fc-event-title">' +
-			event.title +
+			escapeHTML(event.title) +
 			'</span>' +
 			'</span>' +
 			'</td>' +
@@ -909,7 +909,7 @@ $(document).ready(function(){
 		eventDrop: Calendar.UI.moveEvent,
 		eventResize: Calendar.UI.resizeEvent,
 		eventRender: function(event, element) {
-			element.find('.fc-event-title').text($("<div/>").html(event.title).text())
+			element.find('.fc-event-title').text($("<div/>").html(escapeHTML(event.title)).text())
 			element.tipsy({
 				className: 'tipsy-event',
 				opacity: 0.9,


### PR DESCRIPTION
Fix for #205

Just thought I should get it approved by @georgehrke and security master @LukasReschke ;)
