### PR TITLE
Show the backup directory path in the error message.

### DIFF
--- a/updater/lib/updater.php
+++ b/updater/lib/updater.php
@@ -85,7 +85,7 @@ class Updater {
         
 	public static function update($version, $backupBase) {
 		if (!is_dir($backupBase)) {
-			throw new \Exception('Backup directory $backupBase is not found');
+			throw new \Exception("Backup directory $backupBase is not found");
 		}
 
 		set_include_path(


### PR DESCRIPTION
In case of a failure the updater app should show the path.
