### PR TITLE
Gallery: Fix problem with sub-sub directory with special chars

### DIFF
--- a/gallery/js/pictures.js
+++ b/gallery/js/pictures.js
@@ -60,7 +60,7 @@ function deplode(element) {
 }
 
 function openNewGal(album_name) {
-	root = root + decodeURIComponent(album_name) + "/";
+	root = $('<i>').append(root).text() + decodeURIComponent(album_name) + "/";
 	var url = OC.linkTo('gallery', 'index.php');
 	url = url + "&root="+encodeURIComponent(root);
 	//extract only the query part


### PR DESCRIPTION
Hi, 
i thought i had fixed #155 in gallery

but in fact no /o\ 
here is an example path that make it fail ..

/bëßt grétîng/Müller Frank/myphoto.jpg

....

my patch try to avoid this double encoding problem. 

i feared that it will break other things in the gallery with some browsers like ie & cie
