### PR TITLE
update breadcrumbs in texteditor, show notification on save error

### DIFF
--- a/files_texteditor/js/editor.js
+++ b/files_texteditor/js/editor.js
@@ -64,7 +64,7 @@ function setSyntaxMode(ext){
 	}
 }
 
-function showControls(filename,writeperms){
+function showControls(dir,filename,writeperms){
 	// Loads the control bar at the top.
 	// Load the new toolbar.
 	var editorbarhtml = '<div id="editorcontrols" style="display: none;"><div class="crumb svg last" id="breadcrumb_file" style="background-image:url(&quot;'+OC.imagePath('core','breadcrumb.png')+'&quot;)"><p>'+filename.replace(/</, "&lt;").replace(/>/, "&gt;")+'</p></div>';
@@ -72,8 +72,29 @@ function showControls(filename,writeperms){
 		editorbarhtml += '<button id="editor_save">'+t('files_texteditor','Save')+'</button><div class="separator"></div>';
 	}
 	editorbarhtml += '<label for="editorseachval">'+t('files_texteditor','Search:')+'</label><input type="text" name="editorsearchval" id="editorsearchval"><div class="separator"></div><button id="editor_close">'+t('files_texteditor','Close')+'</button></div>';
+	// update breadcrumbs to dir, but remember to restore old breadcrumbs on close
+	//var olddir = $('#dir').value; // we want to be compatible with an optional 'home' breadcrumb, so well go through the breadcrumbs manually
+	
+	$('#controls .crumb').hide();
+	var dirs = dir.split('/');
+	$(dirs).each(function(i,d){
+		if (d=='') {
+			//if sth like a 'Home' breadcrumb exists show it
+			if ($('#controls .crumb:first').data('dir') =='') {
+				$('#controls .crumb:first').show();
+			}
+			return;
+		}
+		var pathToDir = encodeURIComponent(dirs.slice(0,i+1).join('/'));
+		
+		var editorcrumb = '<div class="crumb svg"\n\
+								style="background-image:url(\''+OC.imagePath('core','breadcrumb')+'\')">\n\
+								<a href="'+OC.linkTo('files', 'index.php')+'&dir='+pathToDir+'">'+d+'</a>\n\
+							</div>';
+		$('#controls').append(editorcrumb);
+	});
+	
 	// Change breadcrumb classes
-	$('#controls .last').removeClass('last');
 	$('#controls').append(editorbarhtml);
 	$('#editorcontrols').fadeIn('slow');
 }
@@ -154,8 +175,9 @@ function doFileSave(){
 				if(jsondata.status!='success'){
 					// Save failed
 					$('#editor_save').text(t('files_texteditor','Save'));
-					$('#editor_save').after('<p id="save_result" style="float: left">Failed to save file</p>');
-					$("#editor_save").live('click',doFileSave);
+					$('#notification').html(t('files_texteditor','Failed to save file'));
+					$('#notification').fadeIn();
+					$('#editor_save').live('click',doFileSave);
 				} else {
 					// Save OK
 					// Update mtime
@@ -196,7 +218,7 @@ function showFileEditor(dir,filename){
 					$('.actions,#file_action_panel').fadeOut('slow');
 					$('#content table').fadeOut('slow', function() {
 						// Show the control bar
-						showControls(filename,result.data.write);
+						showControls(dir,filename,result.data.write);
 						// Update document title
 						$('body').attr('old_title', document.title);
 						document.title = filename+' - ownCloud';
@@ -249,6 +271,14 @@ function showFileEditor(dir,filename){
 
 // Fades out the editor.
 function hideFileEditor(){
+	//if sth like a 'Home' breadcrumb exists hide it
+	if ($('#controls .crumb:first').data('dir') =='') {
+		$('#controls .crumb:first').hide();
+	}
+	//remove editor specific breadcrumbs
+	$('#controls .crumb:visible').remove();
+	//show all breadcrumbs again
+	$('#controls .crumb').show();
 	if($('#editor').attr('data-edited') == 'true'){
 		// Hide, not remove
 		$('#editorcontrols').fadeOut('slow',function(){


### PR DESCRIPTION
when opening a text file from a search result the breadcrumbs currently do not reflect the dir containing the file. fixed with this commit.

to make the ui consistent with other apps this pull request also makes the text editor use #notification to display errors
