### PR TITLE
"Poor man's" fix for changed passwords not being considered by Ampache API

### DIFF
--- a/media/lib/media.php
+++ b/media/lib/media.php
@@ -20,10 +20,15 @@ class Media {
 			$name = $params['uid'];
 			$query = \OCP\DB::prepare("SELECT `user_id` from `*PREFIX*media_users` WHERE `user_id` LIKE ?");
 			$uid = $query->execute(array($name))->fetchAll();
+			$password = hash('sha256',$_POST['password']);
 			if (count($uid) == 0) {
-				$password = hash('sha256', $_POST['password']);
 				$query = \OCP\DB::prepare("INSERT INTO `*PREFIX*media_users` (`user_id`, `user_password_sha256`) VALUES (?, ?);");
 				$query->execute(array($name, $password));
+				\OC_Log::write('OC_MEDIA', 'Adding new user '.$name.' to media_users', \OC_Log::DEBUG);
+			} else {
+				$query=\OCP\DB::prepare("UPDATE `*PREFIX*media_users` SET `user_password_sha256`=? WHERE `user_id`=?;");
+				$query->execute(array($password, $name));
+				\OC_Log::write('OC_MEDIA', 'Updating password of existing user '.$name.' in media_users', \OC_Log::DEBUG);
 			}
 		}
 	}


### PR DESCRIPTION
Should fix https://github.com/owncloud/apps/issues/313.
This is however not an optimal solution: The drawback is that the user has to login at least once with the new password in the web interface. But that's a general problem of using the login listener I would say; even for first copying of the user to the media_users table it would be best to react on user creation directly, because at the moment, a user has to login at least once into the web interface before being able to use Ampache via the remote API.

So a better solution might be a hook to register listeners to changed user data (or specifically passwords?) - I'm open to suggestions ;)

If the changed password hook is the preferrable solution, then i would be glad about hints about the hook&listener design in owncloud!
