### PR TITLE
add multiple domains reverse SSL proxy support

### DIFF
--- a/calendar/appinfo/remote.php
+++ b/calendar/appinfo/remote.php
@@ -7,7 +7,7 @@
  */
 OCP\App::checkAppEnabled('calendar');
 
-if(substr($_SERVER["REQUEST_URI"],0,strlen(OC_App::getAppWebPath('calendar').'/caldav.php')) == OC_App::getAppWebPath('calendar'). '/caldav.php') {
+if(substr(OCP\Util::getRequestUri(),0,strlen(OC_App::getAppWebPath('calendar').'/caldav.php')) == OC_App::getAppWebPath('calendar'). '/caldav.php') {
 	$baseuri = OC_App::getAppWebPath('calendar').'/caldav.php';
 }
 
@@ -19,6 +19,7 @@ OC_App::loadApps($RUNTIME_APPTYPES);
 $authBackend = new OC_Connector_Sabre_Auth();
 $principalBackend = new OC_Connector_Sabre_Principal();
 $caldavBackend    = new OC_Connector_Sabre_CalDAV();
+$requestBackend = new OC_Connector_Sabre_Request();
 
 // Root nodes
 $Sabre_CalDAV_Principal_Collection = new Sabre_CalDAV_Principal_Collection($principalBackend);
@@ -34,6 +35,7 @@ $nodes = array(
 
 // Fire up server
 $server = new Sabre_DAV_Server($nodes);
+$server->httpRequest = $requestBackend;
 $server->setBaseUri($baseuri);
 // Add plugins
 $server->addPlugin(new Sabre_DAV_Auth_Plugin($authBackend,'ownCloud'));

--- a/contacts/appinfo/remote.php
+++ b/contacts/appinfo/remote.php
@@ -22,7 +22,7 @@
 
 OCP\App::checkAppEnabled('contacts');
 
-if(substr($_SERVER["REQUEST_URI"], 0, strlen(OC_App::getAppWebPath('contacts').'/carddav.php')) == OC_App::getAppWebPath('contacts').'/carddav.php') {
+if(substr(OCP\Util::getRequestUri(), 0, strlen(OC_App::getAppWebPath('contacts').'/carddav.php')) == OC_App::getAppWebPath('contacts').'/carddav.php') {
 	$baseuri = OC_App::getAppWebPath('contacts').'/carddav.php';
 }
 
@@ -34,6 +34,7 @@ OC_App::loadApps($RUNTIME_APPTYPES);
 $authBackend = new OC_Connector_Sabre_Auth();
 $principalBackend = new OC_Connector_Sabre_Principal();
 $carddavBackend   = new OC_Connector_Sabre_CardDAV();
+$requestBackend = new OC_Connector_Sabre_Request();
 
 // Root nodes
 $principalCollection = new Sabre_CalDAV_Principal_Collection($principalBackend);
@@ -49,6 +50,7 @@ $nodes = array(
 
 // Fire up server
 $server = new Sabre_DAV_Server($nodes);
+$server->httpRequest = $requestBackend;
 $server->setBaseUri($baseuri);
 // Add plugins
 $server->addPlugin(new Sabre_DAV_Auth_Plugin($authBackend, 'ownCloud'));

--- a/contacts/thumbnail.php
+++ b/contacts/thumbnail.php
@@ -24,7 +24,7 @@ OCP\JSON::checkLoggedIn();
 OCP\App::checkAppEnabled('contacts');
 session_write_close();
 
-//OCP\Util::writeLog('contacts', $_SERVER["REQUEST_URI"], OCP\Util::DEBUG);
+//OCP\Util::writeLog('contacts', OCP\Util::getRequestUri(), OCP\Util::DEBUG);
 
 function getStandardImage() {
 	OCP\Response::enableCaching();

--- a/mozilla_sync/lib/utils.php
+++ b/mozilla_sync/lib/utils.php
@@ -205,7 +205,7 @@ class Utils
 	}
 
 	private static function getUrl() {
-		$url = $_SERVER['REQUEST_URI'];
+		$url = \OCP\Util::getRequestUri();
 		$url = str_replace('//','/',$url);
 
 		$pos = strpos($url, 'mozilla_sync');

--- a/remoteStorage/webdav.php
+++ b/remoteStorage/webdav.php
@@ -46,7 +46,7 @@ if(isset($_SERVER['HTTP_ORIGIN'])) {
 	header('Access-Control-Allow-Origin: *');
 }
 
-$path = substr($_SERVER["REQUEST_URI"], strlen($baseuri));
+$path = substr(OCP\Util::getRequestUri(), strlen($baseuri));
 
 $pathParts =  explode('/', $path);
 // for webdav:
@@ -61,6 +61,9 @@ if(count($pathParts) >= 2) {
 	// Create ownCloud Dir
 	$publicDir = new OC_Connector_Sabre_Directory('');
 	$server = new Sabre_DAV_Server($publicDir);
+
+	$requestBackend = new OC_Connector_Sabre_Request();
+	$server->httpRequest = $requestBackend;
 
 	// Path to our script
 	$server->setBaseUri($baseuri.$ownCloudUser);

--- a/user_oauth/remote.php
+++ b/user_oauth/remote.php
@@ -35,12 +35,14 @@ require_once "oauth.php";
 // Backends
 $authBackend = new OC_Connector_Sabre_OAuth($tokenInfoEndpoint, $useResourceOwnerId, $userIdAttributeName);
 $lockBackend = new OC_Connector_Sabre_Locks();
+$requestBackend = new OC_Connector_Sabre_Request();
 
 // Create ownCloud Dir
 $publicDir = new OC_Connector_Sabre_Directory('');
 
 // Fire up server
 $server = new Sabre_DAV_Server($publicDir);
+$server->httpRequest = $requestBackend;
 $server->setBaseUri($baseuri);
 
 // Load plugins

--- a/user_openid/appinfo/app.php
+++ b/user_openid/appinfo/app.php
@@ -6,11 +6,11 @@ if (!in_array ('curl', get_loaded_extensions())) {
 }
 /*
 $userName='';
-if(strpos($_SERVER["REQUEST_URI"],'?') and !strpos($_SERVER["REQUEST_URI"],'=')) {
-	if(strpos($_SERVER["REQUEST_URI"],'/?') !== false) {
-		$userName=substr($_SERVER["REQUEST_URI"],strpos($_SERVER["REQUEST_URI"],'/?')+2);
-	}elseif(strpos($_SERVER["REQUEST_URI"],'.php?') !== false) {
-		$userName=substr($_SERVER["REQUEST_URI"],strpos($_SERVER["REQUEST_URI"],'.php?')+5);
+if(strpos(OCP\Util::getRequestUri(),'?') and !strpos(OCP\Util::getRequestUri(),'=')) {
+	if(strpos(OCP\Util::getRequestUri(),'/?') !== false) {
+		$userName=substr(OCP\Util::getRequestUri(),strpos(OCP\Util::getRequestUri(),'/?')+2);
+	}elseif(strpos(OCP\Util::getRequestUri(),'.php?') !== false) {
+		$userName=substr(OCP\Util::getRequestUri(),strpos(OCP\Util::getRequestUri(),'.php?')+5);
 	}
 }
 

--- a/user_openid_provider/appinfo/app.php
+++ b/user_openid_provider/appinfo/app.php
@@ -28,17 +28,17 @@ OC::$CLASSPATH['OC_OpenIdProviderUserSession'] = 'user_openid_provider/lib/OpenI
 OC::$CLASSPATH['OC_OpenIdProviderStorage'] = 'user_openid_provider/lib/OpenIdProviderStorage.php';
 
 $userName='';
-if(strpos($_SERVER["REQUEST_URI"],'?') and !strpos($_SERVER["REQUEST_URI"],'=')){
-	if(strpos($_SERVER["REQUEST_URI"],'/?') !== false){
-		$userName=substr($_SERVER["REQUEST_URI"],strpos($_SERVER["REQUEST_URI"],'/?')+2);
-	}elseif(strpos($_SERVER["REQUEST_URI"],'.php?') !== false){
-		$userName=substr($_SERVER["REQUEST_URI"],strpos($_SERVER["REQUEST_URI"],'.php?')+5);
+if(strpos(OCP\Util::getRequestUri(),'?') and !strpos(OCP\Util::getRequestUri(),'=')){
+	if(strpos(OCP\Util::getRequestUri(),'/?') !== false){
+		$userName=substr(OCP\Util::getRequestUri(),strpos(OCP\Util::getRequestUri(),'/?')+2);
+	}elseif(strpos(OCP\Util::getRequestUri(),'.php?') !== false){
+		$userName=substr(OCP\Util::getRequestUri(),strpos(OCP\Util::getRequestUri(),'.php?')+5);
 	}
 }
 $remote_token = 'openid_provider';
-if (($pos = strpos($_SERVER["REQUEST_URI"],$remote_token)) !== false) {
+if (($pos = strpos(OCP\Util::getRequestUri(),$remote_token)) !== false) {
 	$pos += strlen($remote_token)+1;
-	$userName = substr($_SERVER['REQUEST_URI'],$pos);
+	$userName = substr(OCP\Util::getRequestUri(),$pos);
 }
 //die('username: ' . $userName);
 if ($userName != '') {

--- a/user_openid_provider/templates/main.php
+++ b/user_openid_provider/templates/main.php
@@ -1,4 +1,4 @@
 <form>
 <h1>OpenId page</h1>
-<?php echo $_SERVER['REQUEST_URI'] ?>
+<?php echo OCP\Util::getRequestUri() ?>
 </form>


### PR DESCRIPTION
Add support for a reverse proxy that handles multiple domains via different
web roots (https://proxy.tld/domain.tld/owncloud) and only forwards SSL
connections unencrypted to the web server.

As the reverse proxy web root is transparent for the web server the
REQUEST_URI and SCRIPT_NAME need manual adjustments. This patch replace
the direct use of this _SERVER variables with function calls. Additionally
it adds a Sabre request backend that extends the Sabre_HTTP_Request to use
the same functions.
