### PR TITLE
Update files_texteditor/ajax/loadfile.php

### DIFF
--- a/files_texteditor/ajax/loadfile.php
+++ b/files_texteditor/ajax/loadfile.php
@@ -37,16 +37,44 @@ if(!empty($filename))
 	{
 		$mtime = OC_Filesystem::filemtime($path);
 		$filecontents = OC_Filesystem::file_get_contents($path);
-		$filecontents = iconv(mb_detect_encoding($filecontents), "UTF-8", $filecontents);
+		$encoding = detectUTF8($filecontents) ? "UTF-8" : "ISO-8859-1"; // use this check, because mb_detect_encoding has a bug
+                $filecontents = iconv($encoding, "UTF-8//IGNORE", $filecontents); // use //IGNORE otherwise file is truncated
 		OCP\JSON::success(array('data' => array('filecontents' => $filecontents, 'write' => 'true', 'mtime' => $mtime)));
 	}
 	else
 	{
 		$mtime = OC_Filesystem::filemtime($path);
 		$filecontents = OC_Filesystem::file_get_contents($path);
-		$filecontents = iconv(mb_detect_encoding($filecontents), "UTF-8", $filecontents);
+		$encoding = detectUTF8($filecontents) ? "UTF-8" : "ISO-8859-1"; // use this check, because mb_detect_encoding has a bug
+                $filecontents = iconv($encoding, "UTF-8//IGNORE", $filecontents); // use //IGNORE otherwise file is truncated
 		OCP\JSON::success(array('data' => array('filecontents' => $filecontents, 'write' => 'false', 'mtime' => $mtime)));
 	}
 } else {
 	OCP\JSON::error(array('data' => array( 'message' => 'Invalid file path supplied.')));
+}
+
+// Problem with the editor was, that it did not correctly display non-UTF-files
+// see: https://github.com/owncloud/core/issues/666
+// Stefan Hammes (stefan@hammes.de) @ 18-Jan-2013
+//
+// Reason:
+// The PHP function mb_detect_encoding has a bug with UTF-8 without BOM
+//
+// Fix:
+// Use the function detectUTF8 below from chris AT w3style.co DOT uk:
+// http://de2.php.net/manual/de/function.mb-detect-encoding.php#68607
+//
+// I checked many detection functions, but only this one works
+
+function detectUTF8($string)
+{
+        return preg_match('%(?:
+        [\xC2-\xDF][\x80-\xBF]        # non-overlong 2-byte
+        |\xE0[\xA0-\xBF][\x80-\xBF]               # excluding overlongs
+        |[\xE1-\xEC\xEE\xEF][\x80-\xBF]{2}      # straight 3-byte
+        |\xED[\x80-\x9F][\x80-\xBF]               # excluding surrogates
+        |\xF0[\x90-\xBF][\x80-\xBF]{2}    # planes 1-3
+        |[\xF1-\xF3][\x80-\xBF]{3}                  # planes 4-15
+        |\xF4[\x80-\x8F][\x80-\xBF]{2}    # plane 16
+        )+%xs', $string);
 }


### PR DESCRIPTION
I fixed the following bug (I put it unintentionally into core, which was not correct, sorry):

https://github.com/owncloud/core/issues/666

I have checked this bug fix with the following file types:

ANSI / ISO-8859-1
UTF-8 with BOM
UTF-8 without BOM

and it worked fine also in owncloud 4.5.5

without the //IGNORE modifier in iconv we get the error:

PHP Notice:  iconv(): Detected an illegal character in input string

on bad UTF-8 files.

Best wishes from Germany
Stefan Hammes
