### PR TITLE
include svg class for IE image fallback, fix #492

### DIFF
--- a/firstrunwizard/templates/wizard.php
+++ b/firstrunwizard/templates/wizard.php
@@ -22,13 +22,13 @@
 
 <h2><?php echo $l->t('Connect your desktop apps to ownCloud');?></h2>
 <a class="button" href="http://doc.owncloud.org/server/5.0/user_manual/calendars.html#synchronising-calendars-with-caldav">
-	<img class="appsmall" src="<?php echo OCP\Util::imagePath('calendar', 'icon.svg'); ?>" /> <?php echo $l->t('Connect your Calendar');?>
+	<img class="appsmall svg" src="<?php echo OCP\Util::imagePath('calendar', 'icon.svg'); ?>" /> <?php echo $l->t('Connect your Calendar');?>
 </a>
 <a class="button" href="http://doc.owncloud.org/server/5.0/user_manual/contacts.html#keeping-your-address-book-in-sync">
-	<img class="appsmall" src="<?php echo OCP\Util::imagePath('settings', 'users.svg'); ?>" /> <?php echo $l->t('Connect your Contacts');?>
+	<img class="appsmall svg" src="<?php echo OCP\Util::imagePath('settings', 'users.svg'); ?>" /> <?php echo $l->t('Connect your Contacts');?>
 </a>
 <a class="button" href="http://doc.owncloud.org/server/5.0/user_manual/connecting_webdav.html">
-	<img class="appsmall" src="<?php echo OCP\Util::imagePath('core', 'places/folder.svg'); ?>" /> <?php echo $l->t('Access files via WebDAV');?>
+	<img class="appsmall svg" src="<?php echo OCP\Util::imagePath('core', 'places/folder.svg'); ?>" /> <?php echo $l->t('Access files via WebDAV');?>
 </a>
 
 <p class="footnote"><?php echo $l->t('There’s more information in the <a href="http://doc.owncloud.org/server/5.0/user_manual/">documentation</a> and on our <a href="http://owncloud.org">website</a>.'); ?><br>


### PR DESCRIPTION
This should fix the issue in the first run wizard with icons not being displayed in IE8. The reason is the SVG fallback only working on images which have the class »svg«.
Weirdly enough, in the screenshot of #492 the close button image isn’t replaced either, which is weird because it already has the class.

@icewind1991 is it possible to make the fallback script to just automatically check on any image? If it’s SVG look for a PNG with the same name, and if it’s PNG just leave it (or maybe if the browser supports it, look if there’s an SVG.

Please check @DeepDiver1975 – if the close button still isn’t replaced, can you check if attaching the »svg« class to the parent a tag of the img works.
