### PR TITLE
Update files_texteditor/ajax/loadfile.php

### DIFF
--- a/files_texteditor/ajax/loadfile.php
+++ b/files_texteditor/ajax/loadfile.php
@@ -37,14 +37,14 @@ if(!empty($filename))
 	{
 		$mtime = \OC\Files\Filesystem::filemtime($path);
 		$filecontents = \OC\Files\Filesystem::file_get_contents($path);
-		$filecontents = iconv(mb_detect_encoding($filecontents), "UTF-8", $filecontents);
+		$filecontents = iconv(mb_detect_encoding($filecontents,implode(", ",mb_list_encodings())), "UTF-8", $filecontents);
 		OCP\JSON::success(array('data' => array('filecontents' => $filecontents, 'write' => 'true', 'mtime' => $mtime)));
 	}
 	else
 	{
 		$mtime = \OC\Files\Filesystem::filemtime($path);
 		$filecontents = \OC\Files\Filesystem::file_get_contents($path);
-		$filecontents = iconv(mb_detect_encoding($filecontents), "UTF-8", $filecontents);
+		$filecontents = iconv(mb_detect_encoding($filecontents,implode(", ",mb_list_encodings())), "UTF-8", $filecontents);
 		OCP\JSON::success(array('data' => array('filecontents' => $filecontents, 'write' => 'false', 'mtime' => $mtime)));
 	}
 } else {


### PR DESCRIPTION
The problem was (Issue #461), that loadfile.php (the file text-editor) did not correctly load Windows ANSI / ISO encoded files.

After much research I found a solution:

You have to specify the possible encodings when calling mb_detect_encoding. Then the detection works. Possibly an error in PHP.

You can list all implemented encodings with mb_list_encodings(). In the above code-change we construct a string suitable for mb_detect_encoding with the implode function.

Believe it or not (better try it): Without the modification, the text-editor does not display Windows-ANSI files correctly, with the modification, it does ;-)

It also recognizes UTF with BOM and without BOM and all other implemented encodings!

With this short commandline PHP code you can test it:.

<?php

// read file specified on command line
$fd = fopen($_SERVER['argv'][1],"r");
$s = fread($fd,10000);
fclose($fd);

// this prints correct encoding for Windows ISO file
echo mb_detect_encoding($s,implode(", ",mb_list_encodings())) . "\n";

// this prints wrong encoding for Windows ISO file
echo mb_detect_encoding($s) . "\n";

?>

Best wishes
Stefan Hammes
