### PR TITLE
fix django_auth

### DIFF
--- a/django_auth/appinfo/info.xml
+++ b/django_auth/appinfo/info.xml
@@ -11,4 +11,7 @@
 	<licence>AGPL</licence>
 	<author>Florian Reinhard florian.reinhard@googlemail.com</author>
 	<require>4</require>
+	<types>
+		<authentication/>
+	</types>
 </info>


### PR DESCRIPTION
If not present, the whole app is not useable / used by owncloud.
