### PR TITLE
Removed leading "app" from user_pwauth/appinfo/app.php

### DIFF
--- a/user_pwauth/appinfo/app.php
+++ b/user_pwauth/appinfo/app.php
@@ -21,7 +21,7 @@
 *
 */
 
-require_once 'apps/user_pwauth/user_pwauth.php';
+require_once 'user_pwauth/user_pwauth.php';
 
 OC_APP::registerAdmin('user_pwauth','settings');
 


### PR DESCRIPTION
Removed leading "app" from included user_pwauth.php, it breaks multi app directory installs
