### PR TITLE
Calendar: permanently show share and CalDAV icons, no need to hide those in the settings

### DIFF
--- a/calendar/templates/part.choosecalendar.rowfields.php
+++ b/calendar/templates/part.choosecalendar.rowfields.php
@@ -10,7 +10,7 @@
   <?php if($_['calendar']['permissions'] & OCP\PERMISSION_SHARE) { ?>
   <a href="#" class="share" data-item-type="calendar" data-item="<?php echo $_['calendar']['id']; ?>"
 	data-possible-permissions="<?php echo $_['calendar']['permissions'] ?>"
-	title="<?php echo $l->t('Share Calendar') ?>" class="action"><img class="svg action" src="<?php echo (!$_['shared']) ? OCP\Util::imagePath('core', 'actions/share.svg') : OCP\Util::imagePath('core', 'actions/shared.svg') ?>"></a>
+	title="<?php echo $l->t('Share Calendar') ?>" class="action permanent"><img class="svg" src="<?php echo (!$_['shared']) ? OCP\Util::imagePath('core', 'actions/share.svg') : OCP\Util::imagePath('core', 'actions/shared.svg') ?>"></a>
   <?php } ?>
 </td>
 <td width="20px">
@@ -21,7 +21,7 @@ if($_['calendar']['userid'] == OCP\USER::getUser()){
 	$caldav = rawurlencode(html_entity_decode($_['calendar']['uri'], ENT_QUOTES, 'UTF-8')) . '_shared_by_' . $_['calendar']['userid'];
 }
 ?>
-  <a href="#" id="chooseCalendar-showCalDAVURL" data-user="<?php echo OCP\USER::getUser() ?>" data-caldav="<?php echo $caldav ?>" title="<?php echo $l->t('CalDav Link') ?>" class="action"><img class="svg action" src="<?php echo OCP\Util::imagePath('core', 'actions/public.svg') ?>"></a>
+  <a href="#" id="chooseCalendar-showCalDAVURL" data-user="<?php echo OCP\USER::getUser() ?>" data-caldav="<?php echo $caldav ?>" title="<?php echo $l->t('CalDav Link') ?>" class="action permanent"><img class="svg" src="<?php echo OCP\Util::imagePath('core', 'actions/public.svg') ?>"></a>
 </td>
 <td width="20px">
   <a href="<?php echo OCP\Util::linkTo('calendar', 'export.php') . '?calid=' . $_['calendar']['id'] ?>" title="<?php echo $l->t('Download') ?>" class="action"><img class="svg action" src="<?php echo OCP\Util::imagePath('core', 'actions/download.svg') ?>"></a>


### PR DESCRIPTION
Fixes the CalDAV link being hard to find, as blogged about in http://www.bitblokes.de/2013/02/auf-einem-sehr-guten-weg-unterschiede-von-owncloud-5-beta-1-und-owncloud-4-5/ (German)

There’s no need to only show these actions on hover because it’s in the settings anyway. This is a quick fix to make that more discoverable.

Check it @georgehrke @karlitschek 
