### PR TITLE
Consolidate creation of default calendars back into the calendar lib

### DIFF
--- a/calendar/index.php
+++ b/calendar/index.php
@@ -11,7 +11,7 @@ OCP\App::checkAppEnabled('calendar');
 // Create default calendar ...
 $calendars = OC_Calendar_Calendar::allCalendars(OCP\USER::getUser(), false);
 if( count($calendars) == 0) {
-	OC_Calendar_Calendar::addCalendar(OCP\USER::getUser(),'Default calendar');
+	OC_Calendar_Calendar::addDefaultCalendars(OCP\USER::getUser());
 	$calendars = OC_Calendar_Calendar::allCalendars(OCP\USER::getUser(), true);
 }
 

--- a/calendar/lib/calendar.php
+++ b/calendar/lib/calendar.php
@@ -118,6 +118,21 @@ class OC_Calendar_Calendar{
 	}
 
 	/**
+	 * @brief Creates default calendars
+	 * @param string $userid
+	 * @return boolean
+	 */
+	public static function addDefaultCalendars($userid = null) {
+		if(is_null($userid)) {
+			$userid = OCP\USER::getUser();
+		}
+		
+		$id = self::addCalendar($userid,'Default calendar');
+
+		return true;
+	}
+
+	/**
 	 * @brief Creates a new calendar from the data sabredav provides
 	 * @param string $principaluri
 	 * @param string $uri
@@ -243,7 +258,7 @@ class OC_Calendar_Calendar{
 
 		OCP\Util::emitHook('OC_Calendar', 'deleteCalendar', $id);
 		if(OCP\USER::isLoggedIn() and count(self::allCalendars(OCP\USER::getUser())) == 0) {
-			self::addCalendar(OCP\USER::getUser(),'Default calendar');
+			self::addDefaultCalendars(OCP\USER::getUser());
 		}
 
 		return true;

--- a/calendar/lib/hooks.php
+++ b/calendar/lib/hooks.php
@@ -16,7 +16,7 @@ class OC_Calendar_Hooks{
 	 * @return array
 	 */
 	public static function createUser($parameters) {
-		OC_Calendar_Calendar::addCalendar($parameters['uid'],'Default calendar');
+		OC_Calendar_Calendar::addDefaultCalendars($parameters['uid']);
 
 		return true;
 	}


### PR DESCRIPTION
Please pull this small code tidy. 

It simply consolidates the creation of default calendars back into the calendar lib. It's a pre-requisite to a later change which will adjust the default calendar names (or perhaps make them more customisable)

First pull request - please guide on procedure...

Signed-off: Ed W ed@wildgooses.com
