### PR TITLE
OC5 beta 2 - text editor does not open

### DIFF
--- a/files_texteditor/ajax/loadfile.php
+++ b/files_texteditor/ajax/loadfile.php
@@ -36,7 +36,7 @@ if(!empty($filename))
 	$writeable = \OC\Files\Filesystem::isUpdatable($path) ? 'true' : 'false';
 	$mtime = \OC\Files\Filesystem::filemtime($path);
 	$filecontents = \OC\Files\Filesystem::file_get_contents($path);
-	$encoding = mb_detect_encoding($filecontents."a", "UTF-8, WINDOWS-1252, ISO-8859-15, ISO-8859-1, ASCII", TRUE);
+	$encoding = mb_detect_encoding($filecontents."a", "UTF-8, WINDOWS-1252, ISO-8859-15, ISO-8859-1, ASCII", true);
 	if ($encoding == "") {
 		// set default encoding if it couldn't be detected
 		$encoding = 'ISO-8859-15';


### PR DESCRIPTION
I think I've fixed a problem in the detection of the file encoding which prevents a text file from being opened when `mb_detect_encoding` doesn't return a value. This effect has been described here:

`http://php.net/manual/de/function.mb-detect-encoding.php`

In case that the file encoding is not recognized, the default `ISO-8859-15` is used. I don't know if an ownCloud function exists which is able to determine the systems default encoding. If yes, it would be worse to use that value as a default otherwise the given value should be ok for the beginning.

By the way this problem has already been reported, but not yet fixed, with https://github.com/owncloud/apps/issues/297
