### PR TITLE
Sync default calendar creation code with contacts app

### DIFF
--- a/calendar/lib/calendar.php
+++ b/calendar/lib/calendar.php
@@ -15,7 +15,7 @@
  *     userid VARCHAR(255),
  *     displayname VARCHAR(100),
  *     uri VARCHAR(100),
- *     active INTEGER UNSIGNED NOT NULL DEFAULT '0',
+ *     active INTEGER UNSIGNED NOT NULL DEFAULT '1',
  *     ctag INTEGER UNSIGNED NOT NULL DEFAULT '0',
  *     calendarorder INTEGER UNSIGNED NOT NULL DEFAULT '0',
  *     calendarcolor VARCHAR(10),

--- a/contacts/index.php
+++ b/contacts/index.php
@@ -12,7 +12,14 @@
 OCP\User::checkLoggedIn();
 OCP\App::checkAppEnabled('contacts');
 
-// Get active address books. This creates a default one if none exists.
+// Create default address books ...
+$addressbooks = OCA\Contacts\Addressbook::all(OCP\USER::getUser(), false);
+if( count($addressbooks) == 0) {
+    OCA\Contacts\Addressbook::addDefaults(OCP\USER::getUser());
+    $addressbooks = OCA\Contacts\Addressbook::all(OCP\USER::getUser(), true);
+}
+
+// Get active address books.
 $ids = OCA\Contacts\Addressbook::activeIds(OCP\USER::getUser());
 
 // Load the files we need

--- a/contacts/lib/addressbook.php
+++ b/contacts/lib/addressbook.php
@@ -31,6 +31,7 @@
  * uri VARCHAR(100),
  * description TEXT,
  * ctag INT(11) UNSIGNED NOT NULL DEFAULT '1'
+ * active INT(11) UNSIGNED NOT NULL DEFAULT '1',
  * );
  *
  */
@@ -77,10 +78,6 @@ class Addressbook {
 		if($shared === true) {
 			$addressbooks = array_merge($addressbooks, \OCP\Share::getItemsSharedWith('addressbook', Share_Backend_Addressbook::FORMAT_ADDRESSBOOKS));
 		}
-		if(!$active && !count($addressbooks)) {
-			$id = self::addDefault($uid);
-			return array(self::find($id),);
-		}
 		return $addressbooks;
 	}
 
@@ -94,7 +91,7 @@ class Addressbook {
 			$uid = \OCP\USER::getUser();
 		}
 
-		// query all addressbooks to force creation of default if it desn't exist.
+		// query all addressbooks.
 		$activeaddressbooks = self::all($uid);
 		$ids = array();
 		foreach($activeaddressbooks as $addressbook) {
@@ -161,10 +158,11 @@ class Addressbook {
 	}
 
 	/**
-	 * @brief Adds default address book
-	 * @return $id ID of the newly created addressbook or false on error.
+	 * @brief Creates default address books
+	 * @param string $userid
+	 * @return boolean
 	 */
-	public static function addDefault($uid = null) {
+	public static function addDefaults($uid = null) {
 		if(is_null($uid)) {
 			$uid = \OCP\USER::getUser();
 		}
@@ -172,7 +170,7 @@ class Addressbook {
 		if($id !== false) {
 			self::setActive($id, true);
 		}
-		return $id;
+		return true;
 	}
 
 	/**
@@ -388,7 +386,7 @@ class Addressbook {
 		\OCP\Share::unshareAll('addressbook', $id);
 
 		if(count(self::all(\OCP\User::getUser())) == 0) {
-			self::addDefault();
+			self::addDefaults();
 		}
 
 		return true;

--- a/contacts/lib/hooks.php
+++ b/contacts/lib/hooks.php
@@ -43,7 +43,7 @@ class Hooks{
 	 * @return array
 	 */
 	static public function createUser($parameters) {
-		Addressbook::addDefault($parameters['uid']);
+		Addressbook::addDefaults($parameters['uid']);
 		return true;
 	}
 


### PR DESCRIPTION
Please review this small code tidy. It (mostly) synchronises default cal/contact creation between the two apps (hint: there is a lot of duplicated code between these apps - perhaps we can consolidate some code?)

Pre-requisite to changing default names for cal/contacts (or making customisable)

ping @georgehrke
