### PR TITLE
Fix lib_scanner ignoring tracknumber tag in vorbis

### DIFF
--- a/media/lib_scanner.php
+++ b/media/lib_scanner.php
@@ -101,12 +101,18 @@ class OC_MEDIA_SCANNER{
 		else if (isset($data['comments']['track_number']))
 		{
 			$track = $data['comments']['track_number'][0];
-			$track = explode('/',$track);
-			$track = $track[0];
+		}
+		else if (isset($data['comments']['tracknumber']))
+		{
+			$track = $data['comments']['tracknumber'][0];
 		}
 		else
 		{
 			$track = 0;
+		}
+		if (is_string($track) && strpos($track, '/')){
+			$track = explode('/',$track);
+			$track = $track[0];
 		}
 		$length=isset($data['playtime_seconds'])?round($data['playtime_seconds']):0;
 


### PR DESCRIPTION
As documented in [1](http://www.xiph.org/vorbis/doc/v-comment.html), the comment field name for the track number
in an ogg vorbis file is TRACKNUMBER.
