### PR TITLE
Small repair of foreach in calendar/templates/part.showevent.php

### DIFF
--- a/calendar/templates/part.showevent.php
+++ b/calendar/templates/part.showevent.php
@@ -28,7 +28,7 @@
 							print_unescaped('<li>' . OC_Util::sanitizeHTML($categorie) . '</li>');
 						}
 					}else{
-						print_unescaped('<li>' . $_['categories'] . '</li>');
+						print_unescaped('<li>' . OC_Util::sanitizeHTML($_['categories']) . '</li>');
 					}
 					print_unescaped('</ul>');
 				}


### PR DESCRIPTION
Small repair of Warning (and showing category of event) in show event shared from another user.

Warning: Invalid argument supplied for foreach() in /var/www/owncloud/apps/calendar/templates/part.showevent.php on line 26

Issue: https://github.com/owncloud/apps/issues/678
