### PR TITLE
bug fix: add content-type to textresponse header

### DIFF
--- a/appframework/http/textresponse.php
+++ b/appframework/http/textresponse.php
@@ -41,7 +41,7 @@ class TextResponse extends Response {
 	public function __construct($content, $contentType='plain'){
 		parent::__construct();
 		$this->content = $content;
-		$this->addHeader('text/' . $contentType);
+		$this->addHeader('Content-type: text/' . $contentType);
 	}
 
 


### PR DESCRIPTION
other wise, the Content-type will always be text/html even though you
pass 'xml' as the second argument to the constructor.
