### PR TITLE
fix news app feed update when running as cron job

### DIFF
--- a/news/db/feedmapper.php
+++ b/news/db/feedmapper.php
@@ -52,9 +52,16 @@ class FeedMapper {
 	 * @returns
 	 */
 	public function findAll() {
-		$query = 'SELECT * FROM ' . self::tableName . ' WHERE user_id = ?';
-		$stmt = \OCP\DB::prepare($query);
-		$result = $stmt->execute(array($this->userid));
+		if ($this->userid) {
+			$query = 'SELECT * FROM ' . self::tableName . ' WHERE user_id = ?';
+			$stmt = \OCP\DB::prepare($query);
+			$result = $stmt->execute(array($this->userid));
+		}
+		else {
+			$query = 'SELECT * FROM ' . self::tableName;
+			$stmt = \OCP\DB::prepare($query);
+			$result = $stmt->execute();
+		}
 
 		$feeds = array();
 		while($row = $result->fetchRow()){


### PR DESCRIPTION
FeedMapper use getUser as the initial id to iterate feed belong, so it will get nothing since findAll filter all feed by user id, here we change findAll to get all feeds when userid is false, to fix the updates.
