### PR TITLE
Make images in gallery ordered

### DIFF
--- a/gallery/js/gallery.js
+++ b/gallery/js/gallery.js
@@ -30,6 +30,7 @@ Gallery.fillAlbums = function () {
 };
 Gallery.fillAlbums.fill = function (albums, images) {
 	var imagePath, albumPath, parent;
+	images.sort();
 	for (i = 0; i < images.length; i++) {
 		imagePath = images[i];
 		albumPath = OC.dirname(imagePath);


### PR DESCRIPTION
In 5.0 the images are not ordered, but chaotic.
They were ordered sometimes in 4.5
