### PR TITLE
Impress App doesn't mess around with styling of other Applications or the core.

### DIFF
--- a/impress/css/style.css
+++ b/impress/css/style.css
@@ -4,13 +4,12 @@
 
 #content { background:#ffffff; }
 #emptyfolder { position:absolute; margin:10em 0 0 10em; font-size:1.5em; font-weight:bold; color:#888; text-shadow:#fff 0 1px 0; }
-table {position: relative; top: 33px; width: 100%;}
-table th {color:#999;}
-table th#impressImg, table th#impressName, table th#impressSize, table th#impressDate { font-weight:200; border-bottom:2px solid #ccc; }
-table th#impressName {width:95em; }
-table th#impressSize {padding:0 1em; text-align:left; }
-table th#impressDate { padding: 0 1em; }
-.impresslist { padding:6px; width:100%;}
+.impresslist {position: relative; top: 33px; width: 100%; padding:6px; }
+.impresslist th {color:#999;}
+.impresslist th#impressImg, .impresslist th#impressName, .impresslist th#impressSize, .impresslist th#impressDate { font-weight:200; border-bottom:2px solid #ccc; }
+.impresslist th#impressName {width:95em; }
+.impresslist th#impressSize {padding:0 1em; text-align:left; }
+.impresslist th#impressDate { padding: 0 1em; }
 .impresslist tr { border-bottom:1px solid #eee; }
 .impresslist tr:hover {background:#f8f8f8;}
 .impresslist tr td {  padding:5px; border-bottom:2px solid #ddd; }


### PR DESCRIPTION
I don't know the logic behind this, how Impress App's stylesheet affects the Calendar's layout and so of other application/core that use tables but changing from table to a class specific for Impress is solving it. 
Reference : https://github.com/owncloud/apps/issues/570 and https://github.com/owncloud/apps/issues/818
Please check @karlitschek @jancborchardt @arkascha @tanghus 
