### PR TITLE
Removes Impress styles from appinfo/app.php.

### DIFF
--- a/impress/appinfo/app.php
+++ b/impress/appinfo/app.php
@@ -21,8 +21,6 @@
  * 
  */
 
-OCP\Util::addStyle( 'impress', 'style');
-
 OCP\App::register(array('order' => 70, 'id' => 'impress', 'name' => 'Impress'));
 
 OCP\App::addNavigationEntry(array(


### PR DESCRIPTION
This is causing Impress App styles on all apps and the core messing with their styles. The styles are already called from the index.php which loads fine. Please check @georgehrke @karlitschek @tanghus.
