### PR TITLE
Avoid Time overlap with the Music Control Icons

### DIFF
--- a/media/css/music.css
+++ b/media/css/music.css
@@ -44,6 +44,7 @@ div.jp-progress {
 	width: 15em;
 	height: 1.2em;
 	padding: 0;
+	margin-left: 3em;
 }
 
 div.jp-seek-bar {


### PR DESCRIPTION
Please check @davidak @jancborchardt. This is solving the issue for me. 
Thanks!
