### PR TITLE
Highlight current sort order in Tasks app 

### DIFF
--- a/tasks/css/style.css
+++ b/tasks/css/style.css
@@ -60,3 +60,5 @@
 .task .due .time{width:6em;}
 
 .task_delete{position:absolute;bottom:2px;right:5px}
+
+input[type="button"].active {color: #6193CF}

--- a/tasks/js/tasks.js
+++ b/tasks/js/tasks.js
@@ -386,6 +386,7 @@ $(document).ready(function(){
 	});
 
 	$('#tasks_order_category').click(function(){
+		$('#controls input[type="button"]').removeClass('active');
 		var tasks = $('#tasks_list .task').not('.clone');
 		var collection = {};
 		tasks.each(function(i, task) {
@@ -421,44 +422,55 @@ $(document).ready(function(){
 			}
 			$('<h1>').text(label).appendTo(container);
 			container.append(collection[labels[index]]);
-		}
+		};
+		$('#tasks_order_category').addClass('active');
 	});
 
 	$('#tasks_order_due').click(function(){
+		$('#controls input[type="button"]').removeClass('active');
 		OC.Tasks.order(function(a, b){
 			a = $(a).data('task').due;
 			b = $(b).data('task').due;
 			return OC.Tasks.bool_string_cmp(a, b);
 		});
+		$('#tasks_order_due').addClass('active');
 	});
 
 	$('#tasks_order_complete').click(function(){
+		$('#controls input[type="button"]').removeClass('active');
 		OC.Tasks.order(function(a, b){
 			return ($(a).data('task').complete - $(b).data('task').complete) ||
 				OC.Tasks.bool_string_cmp($(a).data('task').completed, $(b).data('task').completed);
 		});
+		$('#tasks_order_complete').addClass('active');
 	});
 
 	$('#tasks_order_location').click(function(){
+		$('#controls input[type="button"]').removeClass('active');
 		OC.Tasks.order(function(a, b){
 			a = $(a).data('task').location;
 			b = $(b).data('task').location;
 			return OC.Tasks.bool_string_cmp(a, b);
 		});
+		$('#tasks_order_location').addClass('active');
 	});
 
 	$('#tasks_order_prio').click(function(){
+		$('#controls input[type="button"]').removeClass('active');
 		OC.Tasks.order(function(a, b){
 			return $(a).data('task').priority
 			     - $(b).data('task').priority;
 		});
+		$('#tasks_order_prio').addClass('active');
 	});
 
 	$('#tasks_order_label').click(function(){
+		$('#controls input[type="button"]').removeClass('active');
 		OC.Tasks.order(function(a, b){
 			return $(a).data('task').summary.localeCompare(
 			       $(b).data('task').summary);
 		});
+		$('#tasks_order_label').addClass('active');
 	});
 
 	$('#tasks_addtask').click(function(){


### PR DESCRIPTION
This fixes owncloud/apps#823 .

The button of the current sort order is now switched to light blue (similarly to how the Calendar app does it).

I'm new at all this, so feedback is greatly appreciated. In particular, there's a bit of duplication in the event handlers, so if there's a way to consolidate, let me know.
