### PR TITLE
Handling MP3 files #734

### DIFF
--- a/media/lib/extractor.php
+++ b/media/lib/extractor.php
@@ -41,8 +41,8 @@ class Extractor_GetID3 implements Extractor {
 	 * @return array
 	 */
 	public function extract($path) {
-		$file = \OC\Files\Filesystem::getView()->getAbsolutePath($path);
-		$data = @$this->getID3->analyze('oc://' . $file);
+		$file = \OC\Files\Filesystem::getLocalFile($path);
+		$data = @$this->getID3->analyze($file);
 		\getid3_lib::CopyTagsToComments($data);
 
 		if (!isset($data['comments'])) {


### PR DESCRIPTION
The code does not make sense to me:

``` php
$file = \OC\Files\Filesystem::getView()->getAbsolutePath($path); // relative to www root!
$data = @$this->getID3->analyze('oc://' . $file);                // analyze() cannot recognize 'oc://' prefix
```

I corrected it to (I double checked - it works for me):

``` php
$file = \OC\Files\Filesystem::getLocalFile($path); // get local file name from $path
$data = @$this->getID3->analyze($file);            // analyze that file
```
