### PR TITLE
Fixed some things in internal_messages

### DIFF
--- a/internal_messages/appinfo/app.php
+++ b/internal_messages/appinfo/app.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once 'apps/internal_messages/lib/internalmessages.php';
+OC::$CLASSPATH['OC_INT_MESSAGES'] = 'internal_messages/lib/internalmessages.php';
 
 OCP\Util::addscript('internal_messages','messages');
 OCP\Util::addStyle ('internal_messages','style');


### PR DESCRIPTION
& in XML causes the XML parser to crash with
"String could not be parsed as XML at /owncloud/lib/app.php#519"
substituted the & with "and".

The required path hasn't to be exactly apps/… so I used **DIR**
instead a hardcoded path.
