### PR TITLE
Fix display bug when moving event between calendars (issues 225/352)

### DIFF
--- a/calendar/lib/object.php
+++ b/calendar/lib/object.php
@@ -321,7 +321,7 @@ class OC_Calendar_Object{
 		$stmt = OCP\DB::prepare( 'UPDATE `*PREFIX*calendar_objects` SET `calendarid`=? WHERE `id`=?' );
 		$stmt->execute(array($calendarid,$id));
 
-		OC_Calendar_Calendar::touchCalendar($id);
+		OC_Calendar_Calendar::touchCalendar($calendarid);
 		OCP\Util::emitHook('OC_Calendar', 'moveEvent', $id);
 
 		return true;


### PR DESCRIPTION
Problem:
When you change an event from one calendar/agenda to an other calendar/agenda, it does not appear in the new calendar representation of the calendar app of owncloud.

We think we found the problem in calendar/lib/object.php

In the public static function moveToCalendar line 16 now is:
OC_Calendar_Calendar::touchCalendar($id);

This is probably incorrect because $id is the event-id and not the calendar-id in this function.

It seems to all work fine here when it is changed into:
OC_Calendar_Calendar::touchCalendar($calendarid);

joerioudshoorn and bartnv
