### PR TITLE
quick and dirty close pdf viewer

### DIFF
--- a/files_pdfviewer/js/loader.js
+++ b/files_pdfviewer/js/loader.js
@@ -1,9 +1,10 @@
 function hidePDFviewer() {
-	$('#content table').show();
+	location.reload();
+	/*$('#content table').show();
 	$("#controls").show();
 	$("#editor").show();
 	$('iframe').remove();
-	$('a.action').remove();
+	$('a.action').remove();*/
 }
 
 function showPDFviewer(dir,filename){


### PR DESCRIPTION
If you close pdf viewer next pdf file doesn't open in viewer but gets downloaded. Because I can not find the call for showPDFviewer, in a first attempt I close it by refreshing the page.
