### PR TITLE
close button reimplementation

### DIFF
--- a/files_pdfviewer/3rdparty/pdfjs/viewer.css
+++ b/files_pdfviewer/3rdparty/pdfjs/viewer.css
@@ -801,6 +801,11 @@ html[dir='rtl'] .toolbarButton.pageDown::before {
   content: url(images/toolbarButton-download.png);
 }
 
+.toolbarButton.close::before {
+  display: inline-block;
+  content: url(images/toolbarButton-close.png);
+}
+
 .toolbarButton.bookmark {
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;


### PR DESCRIPTION
Somehow I have to provide the toolbarButton-close.png, but I dont know how it works via github, so if I can just send someone the file I would be happy...

Edit: just found the "choose an image" link and put the close cross here -->![toolbarButton-close](https://f.cloud.github.com/assets/3731697/317582/2a89bc94-9879-11e2-9543-2f128a230712.png)<--
It has to go in "3rdparty/pdfjs/images"
