### PR TITLE
Dirtyfix playlist overlapping controls.

### DIFF
--- a/media/css/music.css
+++ b/media/css/music.css
@@ -2,6 +2,10 @@
  This file is licensed under the Affero General Public License version 3 or later.
  See the COPYING-README file. */
 
+#controls {
+	z-index: 51;
+}
+
 #controls .jp-controls * {
 	display: inline-block;
 }


### PR DESCRIPTION
See screenshot.
Could be reproduced by mousescrolling down in the playlist while you are already at the bottom of the playlist (at least for me in Chromium 27.0.1452.0).
![Screenshot325](https://f.cloud.github.com/assets/1410802/319707/3018af68-98d7-11e2-9afe-3435f1917ff0.png)
