### PR TITLE
Thumbnails of a directory that starts with a "."

### DIFF
--- a/gallery/ajax/getimages.php
+++ b/gallery/ajax/getimages.php
@@ -11,20 +11,10 @@ OCP\JSON::checkAppEnabled('gallery');
 
 $images = \OC\Files\Filesystem::searchByMime('image');
 $user = \OC_User::getUser();
-$img_paths = array();
 
 foreach ($images as &$image) {
 	$path = $user . $image['path'];
-	$pieces = explode(DIRECTORY_SEPARATOR, $path);
-	
-	$skip_iteration = false;
-	foreach($pieces as $piece){
-		if(startsWith($piece,".")){
-			$skip_iteration = true;
-			break;
-		}
-	}	
-	if($skip_iteration){
+	if(strpos($path, DIRECTORY_SEPARATOR.".")){
 		continue;
 	}
 	$image['path'] = $user . $image['path'];


### PR DESCRIPTION
Avoid showing thumbnails of the images that are inside a directory that starts with a "."
Issue : https://github.com/owncloud/apps/issues/891
