### PR TITLE
imprint: Prevent double declaration of OC5's p() functions in backwards compatibility fixes.

### DIFF
--- a/imprint/appinfo/app.php
+++ b/imprint/appinfo/app.php
@@ -40,11 +40,17 @@ if (5>intval(substr(OC_Util::getVersionString(),0,1)))
 // backwards compatibility for OC5's global p() functions
 if (OC_Shorty_Tools::versionCompare('<','4.93')) // OC-5
 {
-	function p($string) {
-		print(OC_Util::sanitizeHTML($string));
+	if ( ! function_exists('p'))
+	{
+		function p($string) {
+			print(OC_Util::sanitizeHTML($string));
+		}
 	}
-	function print_unescaped($string) {
-		print($string);
+	if ( ! function_exists('print_unescaped'))
+	{
+		function print_unescaped($string) {
+			print($string);
+		}
 	}
 }
 


### PR DESCRIPTION
Check if functions already exist before actually declaring them.
