### PR TITLE
fluxx_compensator: Store preferences as user preferences, not as app setting.

### DIFF
--- a/fluxx_compensator/ajax/preference.php
+++ b/fluxx_compensator/ajax/preference.php
@@ -1,0 +1,100 @@
+<?php
+/**
+* @package fluxx-compensator an ownCloud app
+* @category base
+* @author Christian Reiner
+* @copyright 2012-2013 Christian Reiner <foss@christian-reiner.info>
+* @license GNU Affero General Public license (AGPL)
+* @link information http://apps.owncloud.com/content/show.php?content=157091
+*
+* This library is free software; you can redistribute it and/or
+* modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+* License as published by the Free Software Foundation; either
+* version 3 of the license, or any later version.
+*
+* This library is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+*
+* You should have received a copy of the GNU Affero General Public
+* License along with this library.
+* If not, see <http://www.gnu.org/licenses/>.
+*
+*/
+
+/**
+ * @file ajax/preferences.php
+ * @brief Ajax method to store one and query a personal preference
+ * @author Christian Reiner
+ */
+
+$validPreferences = array(
+	'fluxx-status-H'	=> array(
+		'validate'  => create_function('$v','return in_array($v,array("hidden","shown"));'),
+		'normalize' => create_function('$v,$d','return in_array($v,array("hidden","shown"))?$v:$d;') ),
+	'fluxx-status-N'	=> array(
+		'validate'  => create_function('$v','return in_array($v,array("hidden","shown"));'),
+		'normalize' => create_function('$v,$d','return in_array($v,array("hidden","shown"))?$v:$d;') ),
+	'fluxx-position-H'	=> array(
+		'validate'  => create_function('$v','return is_numeric($v) && ($v>=0);'),
+		'normalize' => create_function('$v,$d','return is_numeric($v) && ($v>=0)?floatval($v):floatval($d);') ),
+	'fluxx-position-N'	=> array(
+		'validate'  => create_function('$v','return is_numeric($v) && ($v>0);'),
+		'normalize' => create_function('$v,$d','return is_numeric($v) && ($v>=0)?floatval($v):floatval($d);') ) );
+
+//no apps or filesystem
+$RUNTIME_NOSETUPFS = true;
+
+// Sanity checks
+OCP\JSON::callCheck ( );
+OCP\JSON::checkLoggedIn ( );
+OCP\JSON::checkAppEnabled ( 'fluxx_compensator' );
+
+try
+{
+	// test for valid key
+	switch ( $_SERVER['REQUEST_METHOD'] )
+	{
+		case 'POST':
+			// check if a valid key has been specified
+			if ( ! array_key_exists('key', $_POST) )
+				throw new Exception ( "Missing key in ajax method." );
+			if ( ! array_key_exists($_POST['key'], $validPreferences) )
+				throw new Exception ( "Unknown key in ajax method." );
+			// check for a valid value
+			if ( ! array_key_exists('value', $_POST) )
+				throw new Exception ( "Missing value in ajax method." );
+			if ( ! $validPreferences[$_POST['key']]['validate']($_POST['value']) )
+				throw new Exception ( "Unknown type of value in ajax method." );
+			// normalize value
+			$value = $validPreferences[$_POST['key']]['normalize']($_POST['value'],0);
+			// store preference
+			OCP\Config::setUserValue ( OCP\User::getUser(), 'fluxx_compensator', $_POST['key'], $value );
+			// return success
+			OCP\JSON::success ( array('value'=>$value) );
+			break;
+
+		case 'GET':
+			// check if a valid key has been specified
+			if ( ! array_key_exists('key', $_GET) )
+				throw new Exception ( "Missing key in ajax method." );
+			if ( ! array_key_exists($_GET['key'], $validPreferences) )
+				throw new Exception ( "Unknown key in ajax method." );
+			// check for a valid default value
+			if ( ! array_key_exists('value', $_GET) )
+				throw new Exception ( "Missing value in ajax method." );
+			if ( ! $validPreferences[$_GET['key']]['validate']($_GET['value']) )
+				throw new Exception ( "Unknown type of value in ajax method." );
+			// retrieve value from database, normalize and return it
+			$value = OCP\Config::getUserValue ( OCP\User::getUser(), 'fluxx_compensator', $_GET['key'] );
+			$value = $validPreferences[$_GET['key']]['normalize']($value,$_GET['value']);
+			OCP\JSON::success ( array('value'=>$value) );
+			break;
+
+		default:
+			throw new Exception ( "Unexpected request method '%s'", $_SERVER['REQUEST_METHOD'] );
+	} // switch
+
+} catch ( Exception $e ) { OCP\JSON::error($e->getMessage()); }
+?>

--- a/fluxx_compensator/js/fluxx.js
+++ b/fluxx_compensator/js/fluxx.js
@@ -42,7 +42,8 @@ $(document).ready(function(){
 	$.each(OC.FluXX.Handle, function(){
 		var handle=this;
 		// hide or show the navigation in a persistent manner
-		OC.AppConfig.getValue('fluxx_compensator','fluxx-status-'+handle.Id,'shown',function(status){
+// 		OC.AppConfig.getValue('fluxx_compensator','fluxx-status-'+handle.Id,'shown',function(status){
+		OC.FluXX.preference(false,'fluxx-status-'+handle.Id,'shown',function(status){
 			if ('hidden'==status){
 				OC.FluXX.hide(handle);
 				OC.FluXX.state(handle, false);}
@@ -136,7 +137,8 @@ OC.FluXX={
 		// compute position limits
 		OC.FluXX.limit(handle);
 		// position handle object
-		OC.AppConfig.getValue('fluxx_compensator','fluxx-position-'+handle.Id,handle.Position.Max,function(pos){
+// 		OC.AppConfig.getValue('fluxx_compensator','fluxx-position-'+handle.Id,handle.Position.Max,function(pos){
+		OC.FluXX.preference(false,'fluxx-position-'+handle.Id,handle.Position.Max,function(pos){
 			OC.FluXX.position(handle, pos);
 		});
 		return handle;
@@ -178,7 +180,8 @@ OC.FluXX={
 			).done(function(){
 				dfd.resolve();
 				// store current handle status inside user preferences
-				OC.AppConfig.setValue('fluxx_compensator','fluxx-status-'+handle.Id,'hidden');
+// 				OC.AppConfig.setValue('fluxx_compensator','fluxx-status-'+handle.Id,'hidden');
+				OC.FluXX.preference(true,'fluxx-status-'+handle.Id,'hidden',null);
 			}).fail(dfd.reject)}
 		else dfd.resolve();
 		return dfd.promise();
@@ -251,7 +254,8 @@ OC.FluXX={
 			$(handle.Selector).css('cursor','pointer');
 			$(handle.Selector).find('img').css('cursor','inherit');
 			// store final handle position
-			OC.AppConfig.setValue('fluxx_compensator','fluxx-position-'+handle.Id,handle.Position.Val);
+// 			OC.AppConfig.setValue('fluxx_compensator','fluxx-position-'+handle.Id,handle.Position.Val);
+			OC.FluXX.preference(true,'fluxx-position-'+handle.Id,handle.Position.Val,null);
 		});
 		// reaction on mouse move: position handle
 		$(document).on('mousemove',function(event){
@@ -270,6 +274,38 @@ OC.FluXX={
 			}
 		});
 	}, // OC.FluXX.move
+	/**
+	 * @method OC.FluXX.preference
+	 * @brief Get or set a personal preference
+	 * @author Christian Reiner
+	 */
+	preference:function(set, key, value, callback){
+		switch(set){
+			case true:
+				// set a preference
+				$.when(
+					$.post(OC.filePath('fluxx_compensator', 'ajax', 'preference.php'), {'key':key, 'value':value})
+				).done(function(result){
+					if (callback)
+						callback(result.value);
+					return result.value;
+				}).fail(function(){
+					return value;
+				})
+			default:
+			case false:
+				// get a preference
+				$.when(
+					$.getJSON(OC.filePath('fluxx_compensator','ajax','preference.php')+'?key='+encodeURIComponent(key)+'&value='+encodeURIComponent(value))
+				).done(function(result){
+					if (callback)
+						callback(result.value);
+					return result.value;
+				}).fail(function(){
+					return value;
+				})
+		}
+	}, // OC.FluXX.preference
 	/**
 	* @method OC.FluXX.position
 	* @brief Position handle upon drag action
@@ -301,7 +337,8 @@ OC.FluXX={
 			).done(function(){
 				dfd.resolve();
 				// store current handle status inside user preferences
-				OC.AppConfig.setValue('fluxx_compensator','fluxx-status-'+handle.Id,'shown');
+// 				OC.AppConfig.setValue('fluxx_compensator','fluxx-status-'+handle.Id,'shown');
+				OC.FluXX.preference(true,'fluxx-status-'+handle.Id,'shown',null);
 			}).fail(dfd.reject)}
 		else dfd.resolve();
 		return dfd.promise();


### PR DESCRIPTION
This fixes the issue that positioning the handles was not possible for non privilidged user accounts.
