### PR TITLE
Fixed unallowed chars (<0x20) in XML

### DIFF
--- a/media/lib/ampache.php
+++ b/media/lib/ampache.php
@@ -317,7 +317,9 @@ function get_xml_entity_at_index_0($CHAR) {
 }
 
 function numeric_entity_4_char($char) {
-	if (ord($char) < 32) return "";
+	if (ord($char) < 32) {
+		return "";
+	}
 	return "&#" . str_pad(ord($char), 3, '0', STR_PAD_LEFT) . ";";
 }
 


### PR DESCRIPTION
Added a check in numeric_entity_4_char() to take care of unallowed XML chars which are < 0x20
