### PR TITLE
app:reader - fix "table 'oc_ebook_library' does not exist ..." error

### DIFF
--- a/reader/appinfo/database.xml
+++ b/reader/appinfo/database.xml
@@ -9,7 +9,7 @@
 
  <table>
 
-  <name>*dbprefix*eBook_library</name>
+  <name>*dbprefix*ebook_library</name>
 
   <declaration>
 


### PR DESCRIPTION
Don't use uppercase characters in table name to prevent fatal exception "table 'oc_ebook_library' does not exist ...".
