### PR TITLE
fixing aspect-ratio-bug for ie10 in slideshow.js

### DIFF
--- a/gallery/js/slideshow.js
+++ b/gallery/js/slideshow.js
@@ -48,7 +48,8 @@ jQuery.fn.slideShow.showImage = function (url, preloadUrl) {
 				width = image.width + 'px';
 				top = ((container.height() - image.height) / 2) + 'px';
 			} else {
-				width = '100%';
+				width = container.width()+'px';
+				height = (container.width()/ratio)+'px';				
 				top = ((container.height() - (container.width() / ratio)) / 2) + 'px';
 			}
 		} else {
@@ -56,7 +57,8 @@ jQuery.fn.slideShow.showImage = function (url, preloadUrl) {
 				top = ((container.height() - image.height) / 2) + 'px';
 				height = image.height + 'px';
 			} else {
-				height = '100%';
+				height = container.height()+'px';
+				width = (container.height()*ratio)+"px";
 			}
 		}
 		$(image).css({


### PR DESCRIPTION
Setting both height and width using px-Values instead of just Setting one of the attributes to "100%". Without this fix IE10 does not keep the aspect-ratio of the image. 

Just registered to github to give this feedback. Please re-test. Test coverage with ie10: 50% of the new code. Not tried with other browsers.
