### PR TITLE
slideshow.js: resizing problems, bug in top alignment, ...

### DIFF
--- a/gallery/js/slideshow.js
+++ b/gallery/js/slideshow.js
@@ -35,7 +35,7 @@ jQuery.fn.slideShow.loadImage = function (url) {
 	return jQuery.fn.slideShow.cache[url];
 };
 
-jQuery.fn.slideShow.showImage = function (url) {
+jQuery.fn.slideShow.showImage = function (url, preloadUrl) { 
 	var container = jQuery.fn.slideShow.container;
 	jQuery.fn.slideShow.loadImage(url).then(function (image) {
 		var ratio = image.naturalWidth / image.naturalHeight,
@@ -71,6 +71,9 @@ jQuery.fn.slideShow.showImage = function (url) {
 		});
 		if (jQuery.fn.slideShow.settings.play) {
 			jQuery.fn.slideShow.setTimeout();
+		}
+		if (preloadUrl) {  
+			jQuery.fn.slideShow.loadImage(preloadUrl);  
 		}
 	});
 };


### PR DESCRIPTION
This fixes some more bugs in the showImage-function:

using naturalWidth, naturalHeight instead of width, height.

correctly setting top to 0.

using maxScale:1 istead of using 1:1 for small images
