### PR TITLE
postgres fix for mozilla_sync

### DIFF
--- a/mozilla_sync/lib/storage.php
+++ b/mozilla_sync/lib/storage.php
@@ -276,9 +276,9 @@ class Storage
 			// database framework adds '' characters which cause syntax error in MySql.
 			//
 			// For example:
-			//   - correct     LIMIT 0,5 is correct,
-			//   - not correct LIMIT '0','5'
-			$whereString .= ' LIMIT '. $offset .','. $limit;
+			//   - correct LIMIT 5 OFFSET 0
+			//   - not correct LIMIT '5' OFFSET '0'
+			$whereString .= ' LIMIT '. $limit .' OFFSET '. $offset;
 		}
 
 		return $whereString;


### PR DESCRIPTION
I just found the following error in my postgresql logs:
'''
==> /var/lib/postgresql/9.2/data/postmaster.log <==
ERROR:  LIMIT #,# syntax is not supported at character 171
HINT:  Use separate LIMIT and OFFSET clauses.
STATEMENT:  SELECT payload, name as id, modified, parentid, predecessorid, sortindex, ttl FROM oc_mozilla_sync_wbo WHERE collectionid = $1 AND modified >= CAST( $2 AS DECIMAL(15,2)) LIMIT 0,5000
'''

The same error appears in owcloud.log:
'''
{"app":"PHP","message":"SQLSTATE[42601]: Syntax error: 7 ERROR:  LIMIT #,# syntax is not supported\nLINE 1: ...d = $1 AND modified >= CAST( $2 AS DECIMAL(15,2)) LIMIT 0,50...\n                                                             ^\nHINT:  Use separate LIMIT and OFFSET clauses. at \/var\/www\/cloud.lerya.net\/htdocs\/lib\/db.php#966","level":4,"time":1373349156}
'''

This patch seems to fix this issue. A rapid search on the internet shows that the hinted clauses are supposed to be supported by (at least):
- postgres: http://www.postgresql.org/docs/9.2/static/queries-limit.html
- mysql: https://dev.mysql.com/doc/refman/5.0/en/select.html 'For compatibility with PostgreSQL, MySQL also supports the LIMIT row_count OFFSET offset syntax.'
- sqlite: https://www.sqlite.org/lang_select.html

I only tested with postgresql.
Does owncloud support other backends ?
