### PR TITLE
fix public link downloads - load texteditor only if user is logged in

### DIFF
--- a/files_texteditor/appinfo/app.php
+++ b/files_texteditor/appinfo/app.php
@@ -1,7 +1,7 @@
 <?php
 
 // only load text editor if the user is logged in
-if (\OCP\User::isLoggedIn() === false) {
+if (\OCP\User::isLoggedIn()) {
 	OCP\Util::addStyle('files_texteditor', 'DroidSansMono/stylesheet');
 	OCP\Util::addStyle('files_texteditor', 'style');
 	OCP\Util::addscript('files_texteditor', 'editor');


### PR DESCRIPTION
 load texteditor only if user is logged in, otherwise it will also register for public shares which will block downloads if the user clicks directly on the file.

This should solve https://github.com/owncloud/core/issues/3972

cc @butonic @blizzz 
