### PR TITLE
Update gallery to remove index offset php warning

### DIFF
--- a/gallery/ajax/gallery.php
+++ b/gallery/ajax/gallery.php
@@ -9,7 +9,9 @@
 OCP\JSON::checkLoggedIn();
 OCP\JSON::checkAppEnabled('gallery');
 
-list($owner, $gallery) = explode('/', $_GET['gallery'], 2);
+$split = explode('/', $_GET['gallery'], 2);
+$owner = $split[0];
+$gallery = array_key_exists(1, $split) ? $split[1] : NULL;
 
 $ownerView = new \OC\Files\View('/' . $owner . '/files');
 if ($owner !== OC_User::getUser()) {


### PR DESCRIPTION
In debug mode my logs were filling with these errors when visiting the home page for the gallery app:

```
{"app":"PHP","message":"Undefined offset: 1 at ...\apps\\gallery\\ajax\\gallery.php#12","level":2,"time":1374062637}
```

Not a major issue, but this fix helps keep the log files clean
