### PR TITLE
numRows() returns int

### DIFF
--- a/mozilla_sync/lib/user.php
+++ b/mozilla_sync/lib/user.php
@@ -122,7 +122,7 @@ class User
 		$query = \OCP\DB::prepare( 'SELECT 1 FROM `*PREFIX*mozilla_sync_users` WHERE `sync_user` = ?');
 		$result = $query->execute( array($userHash) );
 
-		return $result->numRows() === '1';
+		return $result->numRows() === 1;
 	}
 
 	/**


### PR DESCRIPTION
numRows() returns an int [1] and should thus be compared to an int and not a string.

This is important for Sync to find the user account on Firefox Mobile for Android, see owncloud/apps#826

[1] http://pear.php.net/package/MDB2/docs/latest/MDB2/MDB2_Result_Common.html#methodnumRows
