### PR TITLE
mozilla_sync: Fix limit and offset for DB.

### DIFF
--- a/mozilla_sync/lib/storage.php
+++ b/mozilla_sync/lib/storage.php
@@ -180,7 +180,7 @@ class Storage
 	* @brief Convert modifiers array to sql string
 	*
 	*/
-	static public function modifiersToString(&$modifiers, &$queryArgs) {
+	static public function modifiersToString(&$modifiers, &$queryArgs, &$limit, &$offset) {
 		$whereString = '';
 
 		//
@@ -263,23 +263,12 @@ class Storage
 		//
 		// limit and offset
 		//
-		$offset = 0;
-		if(isset($modifiers['offset'])) {
-			$offset = intval($modifiers['offset']);
-		}
-		if(isset($modifiers['limit'])) {
-			$limit = intval($modifiers['limit']);
-			//
-			// WARNING!
-			//
-			// LIMIT parameters are passed via string, not array arguments, beacuse
-			// database framework adds '' characters which cause syntax error in MySql.
-			//
-			// For example:
-			//   - correct     LIMIT 0,5 is correct,
-			//   - not correct LIMIT '0','5'
-			$whereString .= ' LIMIT '. $offset .','. $limit;
-		}
+        if(isset($modifiers['limit'])) {
+            $limit = intval($modifiers['limit']);
+        }
+        if(isset($modifiers['offset'])) {
+            $offset = intval($modifiers['offset']);
+        }
 
 		return $whereString;
 	}

--- a/mozilla_sync/lib/storageservice.php
+++ b/mozilla_sync/lib/storageservice.php
@@ -273,9 +273,9 @@ class StorageService extends Service
 		$whereString = 'WHERE `collectionid` = ?';
 		array_push($queryArgs, $collectionId);
 
-		$whereString .= Storage::modifiersToString($modifiers, $queryArgs);
+		$whereString .= Storage::modifiersToString($modifiers, $queryArgs, $limit, $offset);
 
-		$query = \OCP\DB::prepare( 'SELECT ' . $queryFields . ' FROM `*PREFIX*mozilla_sync_wbo` ' . $whereString );
+		$query = \OCP\DB::prepare( 'SELECT ' . $queryFields . ' FROM `*PREFIX*mozilla_sync_wbo` ' . $whereString, $limit, $offset );
 		$result = $query->execute( $queryArgs );
 
 		if($result == false) {
@@ -380,9 +380,9 @@ class StorageService extends Service
 		$whereString = 'WHERE `collectionid` = ?';
 		array_push($queryArgs, $collectionId);
 
-		$whereString .= Storage::modifiersToString($modifiers, $queryArgs);
+		$whereString .= Storage::modifiersToString($modifiers, $queryArgs, $limit, $offset);
 
-		$query = \OCP\DB::prepare( 'DELETE FROM `*PREFIX*mozilla_sync_wbo` ' . $whereString );
+		$query = \OCP\DB::prepare( 'DELETE FROM `*PREFIX*mozilla_sync_wbo` ' . $whereString, $limit, $offset );
 		$result = $query->execute( $queryArgs );
 
 		if($result == false) {


### PR DESCRIPTION
Use Owncloud's $limit and $offset variables in database access. This
makes sure that the SQL is formatted correctly for different SQL variants (such as PostgreSQL).

Fixes owncloud/apps#1198
