### PR TITLE
Cast modified data to float

### DIFF
--- a/mozilla_sync/lib/storageservice.php
+++ b/mozilla_sync/lib/storageservice.php
@@ -162,7 +162,8 @@ class StorageService extends Service
 			}
 
 			$key = $row['name'];
-			$value = $row['modified'];
+            // Return modified as float, not string
+			$value = (float) $row['modified'];
 
 			$resultArray[$key] = $value;
 		}
@@ -289,6 +290,12 @@ class StorageService extends Service
 
 		while (($row = $result->fetchRow())) {
 			$hasData = true;
+            
+            // Return modified as float, not string
+            if ($row['modified'] != null) {
+                $row['modified'] = (float) $row['modified'];
+            }
+
 			if(isset($modifiers['full'])) {
 				OutputData::write($row);
 			}
@@ -431,6 +438,11 @@ class StorageService extends Service
 			Utils::changeHttpStatus(Utils::STATUS_NOT_FOUND);
 			return true;
 		}
+        
+        // Return modified as float, not string
+        if ($row['modified'] != null) {
+            $row['modified'] = (float) $row['modified'];
+        }
 
 		OutputData::write($row);
 		return true;


### PR DESCRIPTION
Numeric datatypes are returned as string from database.
Cast modified data to float to make sure they are returned according to
the specification [1].
This is important for strict parsers such as Firefox Mobile on Android, see owncloud/apps#826

[1] http://docs.services.mozilla.com/storage/apis-1.1.html#id2
