### PR TITLE
Pictures: do not scale up small pictures in slideshow, fix #1268

### DIFF
--- a/gallery/js/slideshow.js
+++ b/gallery/js/slideshow.js
@@ -3,8 +3,7 @@ jQuery.fn.slideShow = function (container, start, options) {
 	start = start || 0;
 	settings = jQuery.extend({
 		'interval': 5000,
-		'play': true,
-		'maxScale': 2
+		'play': true
 	}, options);
 	jQuery.fn.slideShow.container = container;
 	jQuery.fn.slideShow.settings = settings;
@@ -60,20 +59,20 @@ jQuery.fn.slideShow.fitImage = function (container, image) {
 		screenRatio = container.width() / container.height(),
 		width = null, height = null, top = null;
 	if (ratio > screenRatio) {
-		if (container.width() > image.natWidth * jQuery.fn.slideShow.settings.maxScale) {
-			top = ((container.height() - (image.natHeight * jQuery.fn.slideShow.settings.maxScale)) / 2) + 'px';
-			height = (image.natHeight * jQuery.fn.slideShow.settings.maxScale) + 'px';
-			width = (image.natWidth * jQuery.fn.slideShow.settings.maxScale) + 'px';
+		if (container.width() > image.natWidth) {
+			top = ((container.height() - image.natHeight) / 2) + 'px';
+			height = image.natHeight + 'px';
+			width = image.natWidth + 'px';
 		} else {
 			width = container.width()+'px';
 			height = (container.width()/ratio)+'px';
 			top = ((container.height() - (container.width() / ratio)) / 2) + 'px';
 		}
 	} else {
-		if (container.height() > image.natHeight * jQuery.fn.slideShow.settings.maxScale) {
-			top = ((container.height() - (image.natHeight * jQuery.fn.slideShow.settings.maxScale)) / 2) + 'px';
-			height = (image.natHeight * jQuery.fn.slideShow.settings.maxScale) + 'px';
-			width = (image.natWidth * jQuery.fn.slideShow.settings.maxScale) + 'px';
+		if (container.height() > image.natHeight) {
+			top = ((container.height() - image.natHeight) / 2) + 'px';
+			height = image.natHeight + 'px';
+			width = image.natWidth + 'px';
 		} else {
 			top = 0;
 			height = container.height()+'px';


### PR DESCRIPTION
Please review @icewind1991 @butonic @owncloud/designers 

I removed the scaling up completely because it does not make sense for a lot of pictures to be scaled up. Actually most of the time when it’s smaller than the screen it’s probably icons or logos or smaller comics or whatnot which actually turn out to be either better readable in original resolution or look ugly in anything else.
