### PR TITLE
deactivate slideshow on login page

### DIFF
--- a/gallery/js/slideshow.js
+++ b/gallery/js/slideshow.js
@@ -260,6 +260,9 @@ Slideshow._getSlideshowTemplate = function () {
 };
 
 $(document).ready(function () {
+	if ($('#body-login').length > 0) {
+		return true; //deactivate slideshow on login page
+	}
 
 	//close slideshow on esc
 	$(document).keyup(function (e) {


### PR DESCRIPTION
deactivates unnecessary initialization of the slideshow on the login page. also removes another http request because we don't fetch the slideshow template anymore. fixes https://github.com/owncloud/apps/issues/1282

@jancborchardt @icewind1991 @kabum 
