### PR TITLE
use console.log instead of alert, fix #1282

### DIFF
--- a/gallery/js/slideshow.js
+++ b/gallery/js/slideshow.js
@@ -306,7 +306,7 @@ $(document).ready(function () {
 		}
 	})
 		.fail(function () {
-			alert(t('core', 'Error loading slideshow template'));
+			console.log('Error loading slideshow template');
 		});
 
 


### PR DESCRIPTION
At least fix the superficial part of #1282, not showing an alert. What’s the original issue though?

Please review @butonic @Kondou-ger 
