### PR TITLE
Fix Imprint HTML escape string

### DIFF
--- a/imprint/templates/tmpl_settings.php
+++ b/imprint/templates/tmpl_settings.php
@@ -63,7 +63,7 @@
 			<br>
 			<label   for="imprint-usage"   class="imprint-option"></label>
 			<span     id="imprint-usage"   class="imprint-option imprint-hint">
-				<?php p($l->t("You can use html markup (e.g. &lt;br&gt; for a linebreak) and inline style attributes (e.g. &lt;a style=\"color:red;\"&gt;)."));?>
+				<?php p($l->t("You can use html markup (e.g. <br> for a linebreak) and inline style attributes (e.g. <a style=\"color:red;\">)."));?>
 			</span>
 		</div>
   </fieldset>


### PR DESCRIPTION
Imprint admin interface really shows "&lt;br&gt;", this should fix that.
