### PR TITLE
Disable text editor app in public mode when logged in

### DIFF
--- a/files_texteditor/js/editor.js
+++ b/files_texteditor/js/editor.js
@@ -304,6 +304,10 @@ function reopenEditor() {
 
 var is_editor_shown = false;
 $(document).ready(function () {
+	if ($('#isPublic').val()){
+		// disable editor in public mode (not supported yet)
+		return;
+	}
 	if (typeof FileActions !== 'undefined') {
 		FileActions.register('text', 'Edit', OC.PERMISSION_READ, '', function (filename) {
 			showFileEditor($('#dir').val(), filename);


### PR DESCRIPTION
This fixes #5059 by disabling the text editor app from the JS code,
because it's currently not possible to detect public mode from app.php

Please review @karlitschek @schiesbn @DeepDiver1975 @tomneedham 
