### PR TITLE
Encode window.file in PDFViewer as well

### DIFF
--- a/files_pdfviewer/3rdparty/pdfjs/viewer.js
+++ b/files_pdfviewer/3rdparty/pdfjs/viewer.js
@@ -3063,7 +3063,7 @@ document.addEventListener('DOMContentLoaded', function webViewerLoad(evt) {
     });
 
 
-  PDFView.open(OC.linkTo('files', 'ajax/download.php')+"?files="+window.file+"&dir="+encodeURIComponent(window.dir), 1.0);
+  PDFView.open(OC.linkTo('files', 'ajax/download.php')+"?files="+encodeURIComponent(window.file)+"&dir="+encodeURIComponent(window.dir), 1.0);
 }, true);
 
 function updateViewarea() {


### PR DESCRIPTION
Necessary to open files with a + in them …

@DeepDiver1975 @karlitschek @kabum 

@dasunsrule32

Fixes owncloud/core#4316

This should be backported.
