### PR TITLE
Removed extra comma that fails in IE8

### DIFF
--- a/files_videoviewer/js/viewer.js
+++ b/files_videoviewer/js/viewer.js
@@ -34,7 +34,7 @@ var videoViewer = {
 				size = {width: 320, height: 240};
 			}
 			return size;
-		},
+		}
 	},
 	mime : null,
 	file : null,


### PR DESCRIPTION
IE8 complained about a syntax error in the video viewer.

:one: byte change!

@karlitschek @schiesbn @DeepDiver1975 @VicDeo 
