### PR TITLE
After closing the text editor, the file list is reloaded

### DIFF
--- a/files_texteditor/js/editor.js
+++ b/files_texteditor/js/editor.js
@@ -266,7 +266,11 @@ function showFileEditor(dir, filename) {
 
 // Fades out the editor.
 function hideFileEditor() {
-	OC.Breadcrumb.show($('#dir').val());
+	if (window.FileList){
+		// reload the directory content with the updated file size + thumbnail
+		// and also the breadcrumb
+		window.FileList.reload();
+	}
 	if ($('#editor_container').attr('data-edited') == 'true') {
 		// Hide, not remove
 		$('#editorcontrols,#editor_container').hide();


### PR DESCRIPTION
To make sure that the file entry in the file list matches the latest
version of the file, the file list is refreshed upon closing of the
editor.

Fixed #1404
