### PR TITLE
Activity: use SVG icon instead of PNG

### DIFF
--- a/activity/appinfo/app.php
+++ b/activity/appinfo/app.php
@@ -36,7 +36,7 @@ OCP\App::addNavigationEntry(array(
 	'id' => 'activity',
 	'order' => 1,
 	'href' => OCP\Util::linkTo('activity', 'index.php'),
-	'icon' => OCP\Util::imagePath('activity', 'activity.png'),
+	'icon' => OCP\Util::imagePath('activity', 'activity.svg'),
 	'name' => $l->t('Activity')));
 
 // register the hooks for filesystem operations. All other events from other apps has to be send via the public api


### PR DESCRIPTION
Simple small mistake – now we use the SVG icon with PNG fallback for the Activity icon.

@owncloud/designers quick review.
