### PR TITLE
First run wizard must not be displayed in case of install error

### DIFF
--- a/firstrunwizard/js/activate.js
+++ b/firstrunwizard/js/activate.js
@@ -1,6 +1,7 @@
 jQuery(document).ready(function () {
-	//do not show when upgrade is in progress
-	if (jQuery('#upgrade').length === 0) {
+	//do not show when upgrade is in progress or an error message
+	//is visible on the login page
+	if (jQuery('#upgrade').length === 0 && jQuery('#body-login .error').length === 0) {
 		showfirstrunwizard();
 	}
 });


### PR DESCRIPTION
Whenever a post-setup-check error appears on the login page, the first
run wizard must not be displayed.

@karlitschek @schiesbn 
