### PR TITLE
Fixed misplaced cursor in IE8

### DIFF
--- a/files_texteditor/css/style.css
+++ b/files_texteditor/css/style.css
@@ -1,3 +1,8 @@
+.ie8 #editor_container div{
+	/* override core style.css font-size:100% that messes up the editor in IE8 */
+	font-size: 12px !important;
+}
+
 #editor_container #editor {
 	position: relative;
 	display: block;


### PR DESCRIPTION
The CSS reset in core/js/styles.css defines font-size: 100% on most
elements. This messes up the font size calculations of ACE in IE8.

This IE8 specific fix overrides the font-size using a fixed size to make it work.

Fixes https://github.com/owncloud/core/issues/5051

@jancborchardt @tomneedham @karlitschek @kabum 
