### PR TITLE
Now using FileList.setViewerMode in embeded apps

### DIFF
--- a/files_odfviewer/css/odfviewer.css
+++ b/files_odfviewer/css/odfviewer.css
@@ -1,6 +1,6 @@
 #odf-canvas{
   position: relative;
-  top: 37px;
+  top: 44px;
   left: 1px;
   border:1px solid darkgray; 
   box-shadow: 0px 4px 10px #000;

--- a/files_odfviewer/js/viewer.js
+++ b/files_odfviewer/js/viewer.js
@@ -4,41 +4,32 @@ function viewOdf(dir, file) {
     OC.addScript('files_odfviewer','webodf').done(function(){
         var location = fileDownloadPath(dir, file);
 
-        // fade out files menu and add odf menu
-        $('.actions,#file_action_panel').fadeOut('slow').promise().done(function() {
-            // odf action toolbar
-            var odfToolbarHtml =
-                '<div id="odf-toolbar">' +
-                '<button id="odf_close">'+t('files_odfviewer','Close')+
-                '</button></div>';
-            $('#controls').append(odfToolbarHtml);
+		// start viewer mode
+		FileList.setViewerMode(true);
 
-        });
+		// odf action toolbar
+		var odfToolbarHtml =
+			'<div id="odf-toolbar">' +
+			'<button id="odf_close">'+t('files_odfviewer','Close')+
+			'</button></div>';
+		$('#controls').append(odfToolbarHtml);
 
-        // fade out file list and show pdf canvas
-        $('table').fadeOut('slow').promise().done(function(){;
-            var canvashtml = '<div id="odf-canvas"></div>';
-			$('table').after(canvashtml);
-			// in case we are on the public sharing page we shall display the odf into the preview tag
-			$('#preview').html(canvashtml);
+		var canvashtml = '<div id="odf-canvas"></div>';
+		$('table').after(canvashtml);
+		// in case we are on the public sharing page we shall display the odf into the preview tag
+		$('#preview').html(canvashtml);
 
-            var odfelement = document.getElementById("odf-canvas");
-            var odfcanvas = new odf.OdfCanvas(odfelement);
-            odfcanvas.load(location);
-        });
+		var odfelement = document.getElementById("odf-canvas");
+		var odfcanvas = new odf.OdfCanvas(odfelement);
+		odfcanvas.load(location);
     });
 }
 
 function closeOdfViewer(){
-	// Fade out odf-toolbar
-	$('#odf-toolbar').fadeOut('slow');
-	// Fade out editor
-	$('#odf-canvas').fadeOut('slow', function(){
-		$('#odf-toolbar').remove();
-		$('#odf-canvas').remove();
-		$('.actions,#file_access_panel').fadeIn('slow');
-		$('table').fadeIn('slow');	
-	});
+	// Remove odf-toolbar
+	$('#odf-toolbar').remove();
+	$('#odf-canvas').remove();
+	FileList.setViewerMode(false);
 	is_editor_shown = false;
 }
 

--- a/files_texteditor/js/editor.js
+++ b/files_texteditor/js/editor.js
@@ -207,7 +207,9 @@ function showFileEditor(dir, filename) {
 						// Save mtime
 						$('#editor').attr('data-mtime', result.data.mtime);
 						// Initialise the editor
-						$('.actions,#file_action_panel,#content table').hide();
+						if (window.FileList){
+							FileList.setViewerMode(true);
+						}
 						// Show the control bar
 						showControls(dir, filename, result.data.writeable);
 						// Update document title
@@ -273,7 +275,7 @@ function hideFileEditor() {
 		// Fade out editor
 		// Reset document title
 		document.title = $('body').attr('old_title');
-		$('.actions,#file_access_panel').show();
+		FileList.setViewerMode(false);
 		$('#content table').show();
 		OC.Notification.show(t('files_texteditor', 'There were unsaved changes, click here to go back'));
 		$('#notification').data('reopeneditor', true);
@@ -283,7 +285,7 @@ function hideFileEditor() {
 		$('#editor_container, #editorcontrols').remove();
 		// Reset document title
 		document.title = $('body').attr('old_title');
-		$('.actions,#file_access_panel').show();
+		FileList.setViewerMode(false);
 		$('#content table').show();
 		is_editor_shown = false;
 	}
@@ -291,8 +293,7 @@ function hideFileEditor() {
 
 // Reopens the last document
 function reopenEditor() {
-	$('.actions,#file_action_panel').hide();
-	$('#content table').hide();
+	FileList.setViewerMode(false);
 	$('#controls .last').not('#breadcrumb_file').removeClass('last');
 	$('#editor_container').show();
 	$('#editorcontrols').show();


### PR DESCRIPTION
Text editor and ODF viewer now use FileList.setViewerMode() calls to
make sure the controls bar is restored properly to its previous state
upon closing.

CC @tomneedham 

:warning: Don't merge before https://github.com/owncloud/core/pull/5473 as it would break the text editor.
