### PR TITLE
remove explicit class registration, minor whitespace fixes

### DIFF
--- a/activity/appinfo/app.php
+++ b/activity/appinfo/app.php
@@ -21,15 +21,6 @@
  *
  */
 
-
-// register the path of the libraries
-OC::$CLASSPATH['OCA\Activity\Consumer'] = 'activity/lib/lib_consumer.php';
-OC::$CLASSPATH['OCA\Activity\Data'] = 'activity/lib/lib_activity.php';
-OC::$CLASSPATH['OCA\Activity\Hook'] = 'activity/lib/lib_hooks.php';
-OC::$CLASSPATH['OCA\Activity\OCS'] = 'activity/lib/lib_ocs.php';
-OC::$CLASSPATH['OCA\Activity\Search'] = 'activity/lib/lib_search.php';
-
-
 // add an navigation entry
 $l=OC_L10N::get('activity');
 OCP\App::addNavigationEntry(array(
@@ -40,7 +31,7 @@ OCP\App::addNavigationEntry(array(
 	'name' => $l->t('Activity')));
 
 // register the hooks for filesystem operations. All other events from other apps has to be send via the public api
-OCA\Activity\Hook::register();
+OCA\Activity\Hooks::register();
 
 OC_Search::registerProvider('\OCA\Activity\Search');
 

--- a/activity/lib/consumer.php
+++ b/activity/lib/consumer.php
@@ -40,6 +40,6 @@ class Consumer implements IConsumer
 	 * @return mixed
 	 */
 	function receive($app, $subject, $subjectParams, $message, $messageParams, $file, $link, $affectedUser, $type, $priority) {
-		\OCA\Activity\Data::send($app, $subject, $subjectParams, $message, $messageParams, $file, $link, $affectedUser, $type, $priority);
+		Data::send($app, $subject, $subjectParams, $message, $messageParams, $file, $link, $affectedUser, $type, $priority);
 	}
 }

--- a/activity/lib/data.php
+++ b/activity/lib/data.php
@@ -45,7 +45,7 @@ class Data
 	 * @param string $link A link where this event is associated with (optional)
 	 * @return boolean
 	 */
-	public static function send($app, $subject, $subjectparams = array(), $message = '', $messageparams = array(), $file = '', $link = '', $affecteduser = '', $type = 0, $prio = \OCA\Activity\Data::PRIORITY_MEDIUM)
+	public static function send($app, $subject, $subjectparams = array(), $message = '', $messageparams = array(), $file = '', $link = '', $affecteduser = '', $type = 0, $prio = Data::PRIORITY_MEDIUM)
 	{
 
 		$timestamp = time();
@@ -63,7 +63,7 @@ class Data
 
 		// call the expire function only every 1000x time to preserve performance.
 		if (rand(0, 1000) == 0) {
-			\OCA\Activity\Data::expire();
+			Data::expire();
 		}
 
 		// fire a hook so that other apps like notification systems can connect
@@ -105,8 +105,8 @@ class Data
 
 		$activity = array();
 		while ($row = $result->fetchRow()) {
-			$row['subject'] = \OCA\Activity\Data::translation($row['app'],$row['subject'],unserialize($row['subjectparams']));
-			$row['message'] = \OCA\Activity\Data::translation($row['app'],$row['message'],unserialize($row['messageparams']));
+			$row['subject'] = Data::translation($row['app'],$row['subject'],unserialize($row['subjectparams']));
+			$row['message'] = Data::translation($row['app'],$row['message'],unserialize($row['messageparams']));
 			$activity[] = $row;
 		}
 		return $activity;
@@ -131,8 +131,8 @@ class Data
 
 		$activity = array();
 		while ($row = $result->fetchRow()) {
-			$row['subject'] = \OCA\Activity\Data::translation($row['app'],$row['subject'],unserialize($row['subjectparams']));
-			$row['message'] = \OCA\Activity\Data::translation($row['app'],$row['message'],unserialize($row['messageparams']));
+			$row['subject'] = Data::translation($row['app'],$row['subject'],unserialize($row['subjectparams']));
+			$row['message'] = Data::translation($row['app'],$row['message'],unserialize($row['messageparams']));
 			$activity[] = $row;
 		}
 		return $activity;

--- a/activity/lib/ocs.php
+++ b/activity/lib/ocs.php
@@ -38,20 +38,20 @@ class OCS {
 
 		$start = isset($_GET['start']) ? $_GET['start'] : 0;
 		$count = isset($_GET['count']) ? $_GET['count'] : 30;
-		
-		$data=\OCA\Activity\Data::read($start,$count);
-		$activities=array();
+
+		$data = Data::read($start,$count);
+		$activities = array();
 
 		foreach($data as $d) {
-			$activity=array();
-			$activity['id']=$d['activity_id'];
-			$activity['subject']=$d['subject'];
-			$activity['message']=$d['message'];
-			$activity['file']=$d['file'];
-			$activity['link']=$d['link'];
-			$activity['date']=date('c',$d['timestamp']);
-				
-			$activities[]=$activity;
+			$activity = array();
+			$activity['id'] = $d['activity_id'];
+			$activity['subject'] = $d['subject'];
+			$activity['message'] = $d['message'];
+			$activity['file'] = $d['file'];
+			$activity['link'] = $d['link'];
+			$activity['date'] = date('c', $d['timestamp']);
+
+			$activities[] = $activity;
 		}
 
 		return new OC_OCS_Result($activities);
@@ -60,4 +60,3 @@ class OCS {
 
 
 }
-

--- a/activity/lib/search.php
+++ b/activity/lib/search.php
@@ -36,20 +36,19 @@ class Search extends \OC_Search_Provider{
 	* @return search results
 	*/
 	function search($query){
-		
-		$data=\OCA\Activity\Data::search($query,100);
-		
-		$results=array();
+
+		$data = Data::search($query, 100);
+
+		$results = array();
 		foreach($data as $d){
-			$file=$d['file'];
-			$results[]=new \OC_Search_Result(
+			$file = $d['file'];
+			$results[] = new \OC_Search_Result(
 				basename($file),
 				$d['subject'].' ('.\OCP\Util::formatDate($d['timestamp']).')',
-				\OC_Helper::linkTo( 'activity', 'index.php' ),'Activity');
+				\OC_Helper::linkTo( 'activity', 'index.php' ), 'Activity');
 		}
-		
+
 		return $results;
 	}
 
 }
-

--- a/activity/templates/activities.part.php
+++ b/activity/templates/activities.part.php
@@ -102,5 +102,3 @@ if (count($eventsInGroup) > 0){
 }
 echo('</div>'); // boxcontainer
 echo('</div>'); // group
-
-?>


### PR DESCRIPTION
@karlitschek sorry to mess with your code. I removed the explicit class registration and renamed the class files in lib accordingly so they are automagically found by the classloader. I also renamed the Hook class to Hooks, because it contains code for more than one hook. I also removed the unnecessary namespace from classes where applicable and used `self::` instead of `HOOK::` to access static variables. There were also a few whitespaces missing and I found a `?>` that neede to be killed with fire. All of this only took about 25 min.

I want the activities app to be a great success, so I just HAD to polish this a bit. People will have a look at it to learn how things are done in owncloud apps. There are also a lot of lines exceeding our 80 columns limit .... maybe someone could reformat those extraneous method paramters ...

@DeepDiver1975 @karlitschek @kabum @bantu please review.
