### PR TITLE
Fix gallery thumbnail generation

### DIFF
--- a/gallery/lib/thumbnail.php
+++ b/gallery/lib/thumbnail.php
@@ -56,7 +56,7 @@ class Thumbnail {
 		}
 	}
 
-	public function create($imagePath, $square) {
+	private function create($imagePath, $square) {
 		$galleryDir = \OC_User::getHome($this->user) . '/gallery/' . $this->user . '/';
 		$dir = dirname($imagePath);
 		if (!is_dir($galleryDir . $dir)) {


### PR DESCRIPTION
@icewind1991 It seems the create method does not append the username that has been determined in the constructor. The other two commits are cosmetics.

@karlitschek @DeepDiver1975 This might be a reason for thumbnails beeing generated over and over.

may fix #1008 by correcting the path where the created thumbnail is stored.
related PR: https://github.com/owncloud/apps/pull/1189 - should be closed
