### PR TITLE
Thumbnails and picture albums now appear more smoothly

### DIFF
--- a/gallery/css/styles.css
+++ b/gallery/css/styles.css
@@ -46,6 +46,20 @@ button.share {
 	max-height: 200px;
 }
 
+#gallery > a.album,
+#gallery > a.image{
+	opacity: 1;
+	transition: opacity 500ms;
+	-moz-transition: opacity 500ms;
+	-o-transition: opacity 500ms;
+	-ms-transition: opacity 500ms;
+	-webkit-transition: opacity 500ms;
+}
+#gallery > a.album.loading,
+#gallery > a.image.loading{
+	opacity: 0;
+}
+
 #controls > .right {
 	float: right;
 }

--- a/gallery/js/gallery.js
+++ b/gallery/js/gallery.js
@@ -124,12 +124,13 @@ Gallery.view.addImage = function (image) {
 		thumb.queue();
 	} else {
 		link = $('<a/>');
-		link.addClass('image');
+		link.addClass('image loading');
 		link.attr('data-path', image);
 		link.attr('href', Gallery.getImage(image)).attr('rel', 'album').attr('alt', OC.basename(image)).attr('title', OC.basename(image));
 
 		thumb = Thumbnail.get(image);
 		thumb.queue().then(function (thumb) {
+			link.removeClass('loading');
 			link.append(thumb);
 		});
 
@@ -159,7 +160,7 @@ Gallery.view.addAlbum = function (path, name) {
 		link = $('<a/>');
 		label = $('<label/>');
 		link.attr('href', '#' + path);
-		link.addClass('album');
+		link.addClass('album loading');
 		link.click(function () {
 			Gallery.view.viewAlbum(path);
 		});
@@ -170,6 +171,7 @@ Gallery.view.addAlbum = function (path, name) {
 		link.append(label);
 		thumb = Thumbnail.get(thumbs[0], true);
 		thumb.queue().then(function (image) {
+			link.removeClass('loading');
 			link.append(image);
 		});
 


### PR DESCRIPTION
Another small layer of polish for the pictures app: smooth CSS3 fade in animation for when thumbnails / albums appear. It feels less rough.

Please review @jancborchardt @butonic @icewind1991 @karlitschek 
