### PR TITLE
Slideshow is now disabled by default from the gallery app

### DIFF
--- a/gallery/js/gallery.js
+++ b/gallery/js/gallery.js
@@ -298,7 +298,7 @@ $(document).ready(function () {
 		if (location.hash != image) {
 			location.hash = image;
 			Thumbnail.paused = true;
-			Slideshow.start(images, i, {play: Slideshow.playPause.playing});
+			Slideshow.start(images, i);
 		}
 	});
 

--- a/gallery/js/slideshow.js
+++ b/gallery/js/slideshow.js
@@ -251,7 +251,7 @@ Slideshow.playPause = function () {
 		Slideshow.play();
 	}
 };
-Slideshow.playPause.playing = true;
+Slideshow.playPause.playing = false;
 Slideshow._getSlideshowTemplate = function () {
 	var defer = $.Deferred();
 	if (!this.$slideshowTemplate) {


### PR DESCRIPTION
When opening the slideshow from the gallery app it is now also disabled
by default.

This is an addition to https://github.com/owncloud/apps/pull/1461

Please review @jancborchardt @DeepDiver1975 @karlitschek 
