### PR TITLE
enable incognito mode if we open a image over a public link

### DIFF
--- a/gallery/ajax/image.php
+++ b/gallery/ajax/image.php
@@ -16,6 +16,7 @@ if (is_array($linkItem) && isset($linkItem['uid_owner'])) {
 	$owner = $rootLinkItem['uid_owner'];
 	OC_Util::tearDownFS();
 	OC_Util::setupFS($owner);
+	\OC_User::setIncognitoMode(true);
 } else {
 	OCP\JSON::checkLoggedIn();
 


### PR DESCRIPTION
fixes public gallery sharing if encryption is enabled and a different user is logged in

cc @PVince81 
