### PR TITLE
add missing default definitions to gallery

### DIFF
--- a/gallery/appinfo/database.xml
+++ b/gallery/appinfo/database.xml
@@ -1,60 +1,66 @@
 <?xml version="1.0" encoding="ISO-8859-1" ?>
 <database>
-	 <name>*dbname*</name>
-	 <create>true</create>
-	 <overwrite>false</overwrite>
-	 <charset>utf8</charset>
-	 <table>
+	<name>*dbname*</name>
+	<create>true</create>
+	<overwrite>false</overwrite>
+	<charset>utf8</charset>
+	<table>
 		<name>*dbprefix*pictures_images_cache</name>
 		<declaration>
 			<field>
 				<name>uid_owner</name>
 				<type>text</type>
+				<default></default>
 				<notnull>true</notnull>
 				<length>64</length>
 			</field>
 			<field>
 				<name>path</name>
 				<type>text</type>
+				<default></default>
 				<notnull>true</notnull>
 				<length>256</length>
 			</field>
 			<field>
 				<name>width</name>
 				<type>integer</type>
+				<default></default>
 				<notnull>true</notnull>
 				<length>4</length>
 			</field>
 			<field>
 				<name>height</name>
 				<type>integer</type>
+				<default></default>
 				<notnull>true</notnull>
 				<length>4</length>
 			</field>
 		</declaration>
 	</table>
-  <table>
-    <name>*dbprefix*gallery_sharing</name>
-    <declaration>
-      <field>
-        <name>token</name>
-        <type>text</type>
-        <notnull>true</notnull>
-        <length>64</length>
-      </field>
-      <field>
-        <name>gallery_id</name>
-        <type>integer</type>
-        <default>0</default>
-        <notnull>true</notnull>
-        <length>4</length>
-      </field>
-      <field>
-        <name>recursive</name>
-        <type>integer</type>
-        <notnull>true</notnull>
-        <length>1</length>
-      </field>
-    </declaration>
-  </table>
+	<table>
+		<name>*dbprefix*gallery_sharing</name>
+		<declaration>
+			<field>
+				<name>token</name>
+				<type>text</type>
+				<default></default>
+				<notnull>true</notnull>
+				<length>64</length>
+			</field>
+			<field>
+				<name>gallery_id</name>
+				<type>integer</type>
+				<default>0</default>
+				<notnull>true</notnull>
+				<length>4</length>
+			</field>
+			<field>
+				<name>recursive</name>
+				<type>integer</type>
+				<default></default>
+				<notnull>true</notnull>
+				<length>1</length>
+			</field>
+		</declaration>
+	</table>
 </database>


### PR DESCRIPTION
Doctrine reads the schema from the database and receives an emptystring default from postgresql for text columns without a default value. This PR adds the missing definition to the schema so doctrine will no longer consider this a diff.

PR for the core repo is https://github.com/owncloud/core/pull/6346

@karlitschek @DeepDiver1975 @bartv2 @kabum @PVince81 please review.

PS: I also suspect issues with oracle ... let us fix PSQL first.
PPS: also cleans up the whitespace
