### PR TITLE
continue loading thumbnails on error

### DIFF
--- a/gallery/js/thumbnail.js
+++ b/gallery/js/thumbnail.js
@@ -34,6 +34,10 @@ Thumbnail.prototype.load = function () {
 			that.loadingDeferred.resolve(that.image);
 			Thumbnail.processQueue();
 		};
+		this.image.onerror = function () {
+			Thumbnail.loadingCount--;
+			Thumbnail.processQueue();
+		};
 		Thumbnail.loadingCount++;
 		this.image.src = this.url;
 	}


### PR DESCRIPTION
when a thumbnail could not be generated (e.g. because of an invalid png) the thumbnail queue looses a slot for concurrent loading of thumbnails. once that reaches three no more thumbnails will be loaded. this pr will continue loading the next thumbnail when a thumbnail could not be loaded.
- [x] port to master

@icewind1991 @VicDeo @kabum please review
