### PR TITLE
Updating/Setting Personal.email field to the full string, instead of onlly the first char

### DIFF
--- a/user_cas/lib/hooks.php
+++ b/user_cas/lib/hooks.php
@@ -35,7 +35,7 @@ class OC_USER_CAS_Hooks {
 
 			if ($cas_uid == $uid) {
 				if (array_key_exists($casBackend->mailMapping, $attributes)) {
-					$cas_email = $attributes[$casBackend->mailMapping][0];
+					$cas_email = $attributes[$casBackend->mailMapping];
 				}
 
 				if (array_key_exists($casBackend->groupMapping, $attributes)) {


### PR DESCRIPTION
The current code took the only the first char of the mapped email attribute delivered by CAS - this fix maps the email attribute fully to the personal email field.
