### PR TITLE
Fixed user_cas group mappings

### DIFF
--- a/user_cas/lib/hooks.php
+++ b/user_cas/lib/hooks.php
@@ -39,7 +39,7 @@ class OC_USER_CAS_Hooks {
 				}
 
 				if (array_key_exists($casBackend->groupMapping, $attributes)) {
-					$cas_groups = $attributes[$casBackend->groupMapping];
+					$cas_groups = explode( ',', $attributes[$casBackend->groupMapping] );
 				}
 				else if (!empty($casBackend->defaultGroup)) {
 					$cas_groups = array($casBackend->defaultGroup);


### PR DESCRIPTION
The $cas_groups needs to be of type array in order to loop over it later.
