### PR TITLE
Fix viewing shared subfolders in the gallery app.

### DIFF
--- a/gallery/ajax/getimages.php
+++ b/gallery/ajax/getimages.php
@@ -71,7 +71,8 @@ foreach ($sharedSources as $sharedSource) {
 		$shareView = new \OC\Files\View('/' . $owner . '/files' . $path);
 		$sharedImages = $shareView->searchByMime('image');
 		foreach ($sharedImages as $sharedImage) {
-			$sharedImage['path'] = $owner . $sharedSource['file_target'] . '/' . $shareName . $sharedImage['path'];
+			// set the file_source in the path so we can get the original shared folder later
+			$sharedImage['path'] = $owner . '/' . $sharedSource['file_source'] . '/' . $shareName . $sharedImage['path'];
 			$images[] = $sharedImage;
 		}
 	}

--- a/gallery/ajax/image.php
+++ b/gallery/ajax/image.php
@@ -22,7 +22,12 @@ if (is_array($linkItem) && isset($linkItem['uid_owner'])) {
 
 	list($owner, $img) = explode('/', $_GET['file'], 2);
 	if ($owner !== OCP\User::getUser()) {
-		list(, $img) = explode('/', $img, 2);
+		OC_Util::setupFS($owner);
+		$view = new \OC\Files\View('/' . $owner . '/files');
+		// second part is the (duplicated) share name
+		list($folderId, , $img) = explode('/', $img, 3);
+		$sharedFolder = $view->getPath($folderId);
+		$img = $sharedFolder . '/' . $img;
 	}
 }
 

--- a/gallery/ajax/thumbnail.php
+++ b/gallery/ajax/thumbnail.php
@@ -21,7 +21,12 @@ if (is_array($linkItem) && isset($linkItem['uid_owner'])) {
 
 	list($owner, $img) = explode('/', $_GET['file'], 2);
 	if ($owner !== OCP\User::getUser()) {
-		list(, $img) = explode('/', $img, 2);
+		OC_Util::setupFS($owner);
+		$view = new \OC\Files\View('/' . $owner . '/files');
+		// second part is the (duplicated) share name
+		list($folderId,, $img) = explode('/', $img, 3);
+		$sharedFolder = $view->getPath($folderId);
+		$img = $sharedFolder . '/' . $img;
 	}
 }
 
@@ -31,7 +36,7 @@ if (is_array($linkItem) && isset($linkItem['uid_owner'])) {
 	// prepend path to share
 	$ownerView = new \OC\Files\View('/' . $owner . '/files');
 	$path = $ownerView->getPath($linkItem['file_source']);
-	$img = $path.'/'.$img;
+	$img = $path . '/' . $img;
 }
 
 $square = isset($_GET['square']) ? (bool)$_GET['square'] : false;


### PR DESCRIPTION
Save the id of shared folders in the image path so we can always recreate the original path

Fixes #1434 

cc @butonic @DeepDiver1975 @Wikinaut @karlitschek 
