### PR TITLE
Quickfix using httpS for fonts CDN

### DIFF
--- a/impress/lib/impress.php
+++ b/impress/lib/impress.php
@@ -61,7 +61,7 @@ class Storage {
 	<title>'.$title.'</title>
 
 
-	<link href="http://fonts.googleapis.com/css?family=Open+Sans:regular,semibold,italic,italicsemibold|PT+Sans:400,700,400italic,700italic|PT+Serif:400,700,400italic,700italic" rel="stylesheet" />
+	<link href="https://fonts.googleapis.com/css?family=Open+Sans:regular,semibold,italic,italicsemibold|PT+Sans:400,700,400italic,700italic|PT+Serif:400,700,400italic,700italic" rel="stylesheet" />
 
 	<link href="'.\OCP\Util::linkToAbsolute('impress', 'css/player.css').'" rel="stylesheet" />
     </head>


### PR DESCRIPTION
not using SSL content in secure context will force browser security exceptions.
Perhaps it might be useful to use `OCP\Util::getRequestUri()`
