### PR TITLE
user_external: Check if extensions are enabled before using them

### DIFF
--- a/user_external/lib/ftp.php
+++ b/user_external/lib/ftp.php
@@ -18,7 +18,6 @@ class OC_User_FTP extends OC_User_Backend{
 		if($this->secure) {
 			$this->protocol.='s';
 		}
-		$this->protocol.='://';
 	}
 
 	/**
@@ -30,7 +29,11 @@ class OC_User_FTP extends OC_User_Backend{
 	 * Check if the password is correct without logging in the user
 	 */
 	public function checkPassword($uid, $password) {
-		$url=$this->protocol.$uid.':'.$password.'@'.$this->host.'/';
+		if (false === array_search($this->protocol, stream_get_wrappers())) {
+			OCP\Util::writeLog('user_external', 'ERROR: Stream wrapper not available: ' . $this->protocol, OCP\Util::ERROR);
+			return false;
+		}
+		$url = sprintf('%s://%s:%s@%s/', $this->protocol, $uid, $password, $this->host);
 		$result=@opendir($url);
 		if(is_resource($result)) {
 			return $uid;

--- a/user_external/lib/imap.php
+++ b/user_external/lib/imap.php
@@ -22,6 +22,10 @@ class OC_User_IMAP extends OC_User_Backend{
 	 * Check if the password is correct without logging in the user
 	 */
 	public function checkPassword($uid, $password) {
+		if (!function_exists('imap_open')) {
+			OCP\Util::writeLog('user_external', 'ERROR: PHP imap extension is not installed', OCP\Util::ERROR);
+			return false;
+		}
 		$mbox = @imap_open($this->mailbox, $uid, $password);
 		imap_errors();
 		imap_alerts();


### PR DESCRIPTION
This patch checks if the relevant functionality is actually available
before using it for authentication:
1. check if function imap_open() exists before using it
2. check if smbclient executable exists during smb auth
3. check if ftp/ftps stream wrappers are registered before
   using them for auth

This fixes a crash (white page) that happens when using IMAP authentication
and the IMAP extension is not installed.

This has been requested in PR #1579.
