### PR TITLE
Small performance improvement on imap_open

### DIFF
--- a/user_external/lib/imap.php
+++ b/user_external/lib/imap.php
@@ -42,10 +42,10 @@ class OC_User_IMAP extends \OCA\user_external\Base {
 			OCP\Util::writeLog('user_external', 'ERROR: PHP imap extension is not installed', OCP\Util::ERROR);
 			return false;
 		}
-		$mbox = @imap_open($this->mailbox, $uid, $password);
+		$mbox = @imap_open($this->mailbox, $uid, $password, OP_HALFOPEN);
 		imap_errors();
 		imap_alerts();
-		if($mbox) {
+		if($mbox !== FALSE) {
 			imap_close($mbox);
 			$this->storeUser($uid);
 			return $uid;


### PR DESCRIPTION
Use the OP_HALFOPEN flag to reduce server load. We don't need to open a mailbox, so just don't try
I've also make the check clearer for the opened connection (I know, 2 PR in one, it's bad…)
