### PR TITLE
Fix outdated setting layouts (admin & user page) and wrapping for translation

### DIFF
--- a/admin_migrate/templates/settings.php
+++ b/admin_migrate/templates/settings.php
@@ -1,5 +1,5 @@
 <form id="export" action="#" method="post">
-    <fieldset class="personalblock">
+    <div class="section">
         <h2><?php p($l->t('Export data'));?></h2>
         <p>
         <input type="hidden" name="requesttoken" value="<?php p($_['requesttoken']) ?>" id="requesttoken">
@@ -7,21 +7,21 @@
         <input type="radio" id="export_system" name="export_type" value="system" /><label for="export_system"><?php p($l->t('Only system files'));?></label><br />
         <input type="radio" id="export_value" name="export_type" value="userfiles" /><label for="export_value"><?php p($l->t('Only user data'));?></label><br />
         <input type="submit" name="admin_export" value="<?php p($l->t('Export')); ?>" />
-    </fieldset>
+    </div>
 </form>
 <?php
 /*
  * EXPERIMENTAL
 ?>
 <form id="import" action="#" method="post" enctype="multipart/form-data">
-    <fieldset class="personalblock">
+    <div class="section">
         <h2><?php p($l->t('Import an ownCloud instance. THIS WILL DELETE ALL CURRENT OWNCLOUD DATA'));?></h2>
         <p><?php p($l->t('All current ownCloud data will be replaced by the ownCloud instance that is uploaded.'));?>
         </p>
         <p><input type="file" id="owncloud_import" name="owncloud_import"><label for="owncloud_import"><?php p($l->t('ownCloud Export Zip File'));?></label>
         </p>
         <input type="submit" name="admin_import" value="<?php p($l->t('Import')); ?>" />
-    </fieldset>
+    </div>
 </form>
 <?php
 */

--- a/apptemplate/templates/settings.php
+++ b/apptemplate/templates/settings.php
@@ -1,8 +1,8 @@
 <form id="apptemplate">
-	<fieldset class="personalblock">
-		<strong>App Template</strong><br />
+	<div class="section">
+		<h2><?php p($l->t('App Template'));?></h2><br />
 		<input type="text" name="somesetting" id="somesetting" value="<?php p($_['url']); ?>" placeholder="<?php p($l->t('Some Setting'));?>" />
 		<br />
 		<span class="msg"></span>
-	</fieldset>
+	</div>
 </form>

--- a/external/templates/settings.php
+++ b/external/templates/settings.php
@@ -1,5 +1,5 @@
 <form id="external">
-	<fieldset class="personalblock">
+	<div class="section">
 		<h2><?php p($l->t('External Sites'));?></h2>
 		<ul class="external_sites">
 
@@ -17,5 +17,5 @@
 
         <input type="button" id="add_external_site" value="<?php p($l->t("Add")); ?>" />
 		<span class="msg"></span>
-	</fieldset>
+	</div>
 </form>

--- a/files_antivirus/templates/settings.php
+++ b/files_antivirus/templates/settings.php
@@ -1,5 +1,5 @@
 <form id="antivirus" action="#" method="post">
-	<fieldset class="personalblock">
+	<div class="section">
 		<h2><?php p($l->t('Antivirus Configuration'));?></h2>
 		<p class='av_mode'><label for="av_mode"><?php p($l->t('Mode'));?></label>
 			<select id="av_mode" name="av_mode"><?php print_unescaped(html_select_options(array('executable' => $l->t('Executable'), 'daemon' => $l->t('Daemon'), 'socket' => $l->t('Daemon (Socket)')), $_['av_mode'])) ?></select>
@@ -14,5 +14,5 @@
 		</p>
 		<input type="hidden" name="requesttoken" value="<?php p($_['requesttoken']);?>" />
 		<input type="submit" value="<?php p($l->t('Save'));?>" />
-	</fieldset>
+	</div>
 </form>

--- a/imprint/templates/tmpl_settings.php
+++ b/imprint/templates/tmpl_settings.php
@@ -35,13 +35,13 @@
 
 <!-- settings of app 'imprint' -->
 <form id="imprint">
-	<fieldset class="personalblock">
-		<legend>
+	<div class="section">
+		<h2>
 			<span id="title" class="title">
 				<img class="" src="<?php p(OCP\Util::imagePath("imprint","imprint-dusky.svg")); ?> ">
-				<strong><?php p($l->t("Imprint"));?></strong>
+				<?php p($l->t("Imprint"));?>
 			</span>
-		</legend>
+		</h2>
 		<div id="imprint-options" class="imprint-option">
 			<label for="imprint-option-position" class="imprint-option"><?php p($l->t("Placement").": ");?></label>
 			<select id="imprint-option-position" class="imprint-option" type="select" name="position">
@@ -66,5 +66,5 @@
 				<?php p($l->t("You can use html markup (e.g. <br> for a linebreak) and inline style attributes (e.g. <a style=\"color:red;\">)."));?>
 			</span>
 		</div>
-  </fieldset>
+	</div>
 </form>

--- a/user_migrate/templates/settings.php
+++ b/user_migrate/templates/settings.php
@@ -1,14 +1,14 @@
-<fieldset class="personalblock" id="migration-settings-block">
+<div class="section">
 	<h2><?php p($l->t('Account Export/Import'));?></h2>
 	<?php if(isset($_['error'])) { ?>
 		<h3><?php p($_['error']['error']); ?></h3>
 		<p><?php p($_['error']['hint']); ?></p>
 		<?php } ?>
-	<button id="exportbtn">Export<img class="loadingexport" src="<?php print_unescaped(OCP\Util::imagePath('core', 'loading.gif')); ?>" /></button><br/>
+	<button id="exportbtn"><?php p($l->t('Export'));?><img class="loadingexport" src="<?php print_unescaped(OCP\Util::imagePath('core', 'loading.gif')); ?>" /></button><br/>
 	<form id="import" action="#" method="post" enctype="multipart/form-data">
 		<input type="hidden" name="requesttoken" value="<?php p($_['requesttoken']) ?>" id="requesttoken">
 		<input type="file" id="import_input" name="owncloud_import">
 	</form>
-	<button id="importbtn">Import<img class="loadingimport" src="<?php print_unescaped(OCP\Util::imagePath('core', 'loading.gif')); ?>" /></button>
-</fieldset>
+	<button id="importbtn"><?php p($l->t('Import'));?><img class="loadingimport" src="<?php print_unescaped(OCP\Util::imagePath('core', 'loading.gif')); ?>" /></button>
+</div>
 

--- a/user_oauth/templates/settings.php
+++ b/user_oauth/templates/settings.php
@@ -1,8 +1,8 @@
 <form id="user_oauth">
-    <fieldset class="personalblock">
-        <strong>OAuth</strong><br />
+    <div class="section">
+        <h2>OAuth</h2><br />
         <input type="text" name="introspectionEndpoint" id="introspectionEndpoint" value="<?php p($_['introspectionEndpoint']); ?>" placeholder="<?php p($l->t('Introspection endpoint'));?>" />
         <br />
-        <span class="msg">Provide the OAuth 2.0 Authorization Server introspection endpoint here.</span>
-    </fieldset>
+        <span class="msg"><?php p($l->t('Provide the OAuth 2.0 Authorization Server introspection endpoint here.'));?></span>
+    </div>
 </form>

--- a/user_openid_provider/templates/settings.php
+++ b/user_openid_provider/templates/settings.php
@@ -1,6 +1,6 @@
 <form id="user_openid_provider">
-	<fieldset class="personalblock">
-		<strong><?php p($l->t('OpenID Provider remembered sites', 'user_openid_provider')) ?></strong>
+	<div class="section">
+		<h2><?php p($l->t('OpenID Provider remembered sites', 'user_openid_provider')) ?></h2>
 		<table>
 		<?php foreach($_['trusted_sites'] as $url => $trust): ?>
 			<tr>
@@ -10,5 +10,5 @@
 			</tr>
 		<?php endforeach ?>
 		</table>
-	</fieldset>
+	</div>
 </form>

--- a/user_persona/templates/settings.php
+++ b/user_persona/templates/settings.php
@@ -9,8 +9,8 @@
  * later.
  */
 ?>
-<fieldset class="personalblock">
-    <legend><strong><?php p($l->t('Mozilla Persona login settings')) ?></strong>:</legend>
+<div class="section">
+    <h2><?php p($l->t('Mozilla Persona login settings')) ?>:</h2>
 	<?php p($l->t('IF more than one user has email provided by Persona THEN')); ?>
     <select id="mozilla-persona-policy">
 		<?php foreach ($_['allPolicies'] as $pValue => $pTitle) { ?>
@@ -20,4 +20,4 @@
 			</option>
 		<?php } ?>
     </select>
-</fieldset>
+</div>

--- a/xmpp/templates/adminSettings.php
+++ b/xmpp/templates/adminSettings.php
@@ -1,5 +1,5 @@
 <form id="xmppadmin" action="#" method="post">
-	<fieldset class="personalblock">
+	<div class="section">
 		<h2><?php p($l->t('XMPP Admin Account'));?></h2>
         <p>
         	<label for="usermail"><?php p($l->t('Username'));?>
@@ -19,6 +19,6 @@
 			<input type="text" id="xmppDefaultDomain" name="xmppDefaultDomain" value="<?php p($_['xmppDefaultDomain']);?>">
 		</label>
 	</p>
-        <input type="submit" value="Save" />
-	</fieldset>
+        <input type="submit" value="<?php p($l->t('Save'));?>" />
+	</div>
 </form>

--- a/xmpp/templates/userSettings.php
+++ b/xmpp/templates/userSettings.php
@@ -1,10 +1,10 @@
 <form id="xmppchat" action="#" method="post">
-	<fieldset class="personalblock">
+	<div class="section">
 		<h2><?php p($l->t('XMPP Chat Settings'));?></h2>
 		<p>
 			<input type="checkbox" name="autoroster" id="autoroster" <?php if ($_['autoroster']) p(' checked'); ?>>
 			<label for="autoroster"><?php p($l->t('Auto Add contacts to roster on insert/update'));?></label>
 		</p>
-        <input type="submit" value="Save" />
-	</fieldset>
+        <input type="submit" value="<?php p($l->t('Save'));?>" />
+	</div>
 </form>


### PR DESCRIPTION
`<fieldset class='xxx'>` tags were not used in css files and this was causing settings
to be seen unaligned (enable admin_migration and see the admin page
for example).
changed all fieldsets into `<div class='section'>` instead.

Also wrapped some hardcoded strings with `t()` to enable translations.
