### PR TITLE
Add missing callCheck() to ajax/settings.php in Activity App

### DIFF
--- a/activity/ajax/settings.php
+++ b/activity/ajax/settings.php
@@ -23,6 +23,7 @@
 
 OCP\JSON::checkLoggedIn();
 OCP\JSON::checkAppEnabled('activity');
+OCP\JSON::callCheck();
 
 $notify_email = $notify_stream = array();
 


### PR DESCRIPTION
As per https://github.com/owncloud/apps/issues/1705#issuecomment-39579951

@LukasReschke @karlitschek 
