### PR TITLE
Travis: do not send success notifications, ever

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,3 +32,7 @@ script: ant test
 #notifications:
 #  irc: "irc.freenode.org#travis"
 
+# never send success notifications
+notifications:
+  email:
+    on_success: never


### PR DESCRIPTION
Notifications should only be sent out if the build fails. Successful builds do not warrant annoyance.

@DeepDiver1975 what do you think? If you agree, I would change the Travis configuration of the other repos as well.
