### PR TITLE
Fix infinite loop when fopen failed when obtaining lock

### DIFF
--- a/files_locking/lib/lock.php
+++ b/files_locking/lib/lock.php
@@ -59,6 +59,16 @@ class Lock {
 		$this->path = Filesystem::normalizePath($path);
 	}
 
+	/**
+	 * Acquire read lock on the current file.
+	 * If no existing handle is given, fopen() will be called
+	 * on the file to obtain one.
+	 *
+	 * @param resource $existingHandle existing file handle, defaults to null
+	 *
+	 * @return bool true if the lock could be obtained, false if a timeout
+	 * occurred or the file could not be opened
+	 */
 	protected function obtainReadLock($existingHandle = null) {
 		\OC_Log::write('lock', sprintf('INFO: Read lock requested for %s', $this->path), \OC_Log::DEBUG);
 		$timeout = Lock::$retries;
@@ -66,6 +76,9 @@ class Lock {
 		// Re-use an existing handle or get a new one
 		if(empty($existingHandle)) {
 			$handle = fopen($this->path, 'r');
+			if ($handle === false) {
+				return false;
+			}
 		}
 		else {
 			$handle = $existingHandle;
@@ -90,12 +103,25 @@ class Lock {
 		return true;
 	}
 
+	/**
+	 * Acquire write lock on the current file.
+	 * If no existing handle is given, fopen() will be called
+	 * on the file to obtain one.
+	 *
+	 * @param resource $existingHandle existing file handle, defaults to null
+	 *
+	 * @return bool true if the lock could be obtained, false if a timeout
+	 * occurred or the file could not be opened
+	 */
 	protected function obtainWriteLock($existingHandle = null) {
 		\OC_Log::write('lock', sprintf('INFO: Write lock requested for %s', $this->path), \OC_Log::DEBUG);
 
 		// Re-use an existing handle or get a new one
 		if (empty($existingHandle)) {
 			$handle = fopen($this->path, 'c');
+			if ($handle === false) {
+				return false;
+			}
 		}
 		else {
 			$handle = $existingHandle;


### PR DESCRIPTION
If for some reason fopen() fails in obtainReadLock() or
obtainWriteLock(), the function now returns with false instead of
needlessly trying to acquire a lock.

The original issue had the "false" $handle caused an infinite loop in
the do-while block.

Steps to reproduce:
1. Upload about 200 pictures in a folder
2. Navigate into the folder
3. Quickly, before the previews are created, click select all and delete
4. Go to trashbin
5. Quickly, before the previews are created, click select all and delete

I believe that the issue should happen at step 3 already.
You should see at least one warning entry in the log with "No such file or directory".

Before this fix, an infinite loop was produced.
After this fix, it should fail gracefully.

Fixes #1817

Please review @DeepDiver1975 @icewind1991 @schiesbn 
