### PR TITLE
Setup file locking storage wrapped in setup hook

### DIFF
--- a/files_locking/appinfo/app.php
+++ b/files_locking/appinfo/app.php
@@ -1,13 +1,3 @@
 <?php
 
-// Set up flock
-\OC\Files\Filesystem::addStorageWrapper('oc_flock', function ($mountPoint, $storage) {
-	/**
-	 * @var \OC\Files\Storage\Storage $storage
-	 */
-	if ($storage instanceof \OC\Files\Storage\Storage && $storage->isLocal()) {
-		return new \OCA\Files_Locking\LockingWrapper(array('storage' => $storage));
-	} else {
-		return $storage;
-	}
-});
+OCP\Util::connectHook('OC_Filesystem', 'setup', '\OCA\Files_Locking\LockingWrapper', 'setupWrapper');

--- a/files_locking/lib/lockingwrapper.php
+++ b/files_locking/lib/lockingwrapper.php
@@ -178,5 +178,21 @@ class LockingWrapper extends Wrapper {
 		return $result;
 	}
 
+	/**
+	 * Setup the storate wrapper callback
+	 */
+	public static function setupWrapper() {
+		// Set up flock
+		\OC\Files\Filesystem::addStorageWrapper('oc_flock', function ($mountPoint, $storage) {
+			/**
+			 * @var \OC\Files\Storage\Storage $storage
+			 */
+			if ($storage instanceof \OC\Files\Storage\Storage && $storage->isLocal()) {
+				return new \OCA\Files_Locking\LockingWrapper(array('storage' => $storage));
+			} else {
+				return $storage;
+			}
+		});
+	}
 
 }


### PR DESCRIPTION
This fixes an issue when using file locking + encryption and try to list
a shared mount in the web UI.

Using the setup hook prevents having setupFS() be called twice in a row
and mess up with the mount points.

Please review @schiesbn @icewind1991 @DeepDiver1975 

Fixes https://github.com/owncloud/core/issues/9222
See above ticket for my analysis of the issue.
