### PR TITLE
Do not add share with information for link shares if given.

### DIFF
--- a/activity/lib/hooks.php
+++ b/activity/lib/hooks.php
@@ -147,7 +147,7 @@ class Hooks {
 			$sharedFrom = \OCP\User::getUser();
 			$shareWith = $params['shareWith'];
 
-			if(!empty($shareWith)) {
+			if($params['shareType'] !== \OCP\Share::SHARE_TYPE_LINK) {
 				$subject = 'You shared %s with %s';
 				Data::send('files', $subject, array(substr($params['fileTarget'], 1), $shareWith), '', array(), $params['fileTarget'], $link, \OCP\User::getUser(), 4, Data::PRIORITY_MEDIUM );
 			


### PR DESCRIPTION
When removing the password from a link share, the shareWith information
incorrectly holds the crypted password. We must ignore this and just
generate the normal link share activity

Fix owncloud/activity#75

@cdamken 
