### PR TITLE
Do not try locking directories

### DIFF
--- a/files_locking/lib/lockingwrapper.php
+++ b/files_locking/lib/lockingwrapper.php
@@ -35,6 +35,9 @@ class LockingWrapper extends Wrapper {
 	 */
 	protected function getLock($path, $lockType, $existingHandle = null){
 		$path = Filesystem::normalizePath($this->storage->getLocalFile($path));
+		if(is_dir($path)) {
+			return false;
+		}
 		if(!isset($this->locks[$path])) {
 			$this->locks[$path] = new Lock($path);
 		}
@@ -51,6 +54,9 @@ class LockingWrapper extends Wrapper {
 	 */
 	protected function releaseLock($path, $lockType, $releaseAll = false){
 		$path = Filesystem::normalizePath($this->storage->getLocalFile($path));
+		if(is_dir($path)) {
+			return false;
+		}
 		if(isset($this->locks[$path])) {
 			if($releaseAll) {
 				return $this->locks[$path]->releaseAll();


### PR DESCRIPTION
Some operations like $storage->rename() can replace a target folder with
a source folder. In such cases, the flock app must not try and lock the
folder (only file locking is supported anyway).

Please review @icewind1991 @DeepDiver1975 

Fixes https://github.com/owncloud/core/issues/9099 where the encryption app tries to replace an internal folder with another one using `$storage->rename()`
