### PR TITLE
Enhance external sites app

### DIFF
--- a/external/ajax/setsites.php
+++ b/external/ajax/setsites.php
@@ -7,6 +7,7 @@
  */
 
 
+OCP\JSON::checkAppEnabled('external');
 OCP\User::checkAdminUser();
 OCP\JSON::callCheck();
 
@@ -17,10 +18,23 @@ for ($i = 0; $i < sizeof($_POST['site_name']); $i++) {
 	}
 }
 
+$l=OC_L10N::get('external');
+
+foreach($sites as $site) {
+	if (strpos($site[1], 'https://') === 0) {
+		continue;
+	}
+	if (strpos($site[1], 'http://') === 0) {
+		continue;
+	}
+	OC_JSON::error(array("data" => array( "message" => $l->t('Please enter valid urls - they have to start with either http:// or https://') )));
+	return;
+}
+
 if (sizeof($sites) == 0) {
 	$appConfig = \OC::$server->getAppConfig();
 	$appConfig->deleteKey('external', 'sites');
 } else {
 	OCP\Config::setAppValue('external', 'sites', json_encode($sites));
 }
-echo 'true';
+OC_JSON::success(array("data" => array( "message" => $l->t("External sites saved.") )));

--- a/external/appinfo/app.php
+++ b/external/appinfo/app.php
@@ -21,13 +21,17 @@
  *
  */
 
-OC::$CLASSPATH['OC_External'] = 'external/lib/external.php';
-OCP\Util::addStyle( 'external', 'style');
+use OCA\External\External;
 
+OCP\Util::addStyle( 'external', 'style');
 OCP\App::registerAdmin('external', 'settings');
 
-$sites = OC_External::getSites();
+$sites = External::getSites();
 for ($i = 0; $i < sizeof($sites); $i++) {
 	OCP\App::addNavigationEntry(
-			array('id' => 'external_index' . ($i + 1), 'order' => 80 + $i, 'href' => OCP\Util::linkTo('external', 'index.php') . '?id=' . ($i + 1), 'icon' => OCP\Util::imagePath('external', 'external.png'), 'name' => $sites[$i][0]));
+			array(
+				'id' => 'external_index' . ($i + 1), 'order' => 80 + $i,
+				'href' => OCP\Util::linkTo('external', 'index.php') . '?id=' . ($i + 1),
+				'icon' => OCP\Util::imagePath('external', 'external.png'),
+				'name' => $sites[$i][0]));
 }

--- a/external/index.php
+++ b/external/index.php
@@ -21,21 +21,26 @@
  *
  */
 
-require_once 'lib/external.php';
 
+use OCA\External\External;
+
+OCP\JSON::checkAppEnabled('external');
 OCP\User::checkLoggedIn();
 
 $id = isset($_GET['id']) ? (int)$_GET['id'] : 1;
 
-$sites = OC_External::getSites();
+$sites = External::getSites();
 if (sizeof($sites) >= $id) {
 	$url = $sites[$id - 1][1];
 	OCP\App::setActiveNavigationEntry('external_index' . $id);
 
 	$tmpl = new OCP\Template('external', 'frame', 'user');
 	//overwrite x-frame-options
-	$tmpl->addHeader('X-Frame-Options', 'ALLOW-FROM *');
+	header('X-Frame-Options: ALLOW-FROM *');
 
 	$tmpl->assign('url', $url);
 	$tmpl->printPage();
+} else {
+	\OC_Util::redirectToDefaultPage();
 }
+

--- a/external/js/admin.js
+++ b/external/js/admin.js
@@ -1,7 +1,8 @@
 $(document).ready(function(){
-    	newSiteHtml = '<li><input type="text" class="site_name" name="site_name[]" value="" placeholder="Name" />\n\
-    <input type="text" name="site_url[]" class="site_url" value=""  placeholder="URL" />\n\
-<img class="svg action delete_button" src="'+OC.imagePath("core", "actions/delete") +'" title="Remove site" /></li>';
+	var newSiteHtml = '<li><input type="text" class="site_name" name="site_name[]" value="" placeholder="Name" />\n' +
+		'<input type="text" name="site_url[]" class="site_url" value=""  placeholder="URL" />' +
+		'<img class="svg action delete_button" src="' +
+		OC.imagePath("core", "actions/delete") +'" title="Remove site" /></li>';
 
 	// Handler functions
 	function addSiteEventHandler(event) {
@@ -21,16 +22,17 @@ $(document).ready(function(){
 
 	function saveSites() {
 		var post = $('#external').serialize();
+		OC.msg.startSaving('#external .msg');
 		$.post( OC.filePath('external','ajax','setsites.php') , post, function(data) {
-			// OC.msg.finishedSaving('#site_name .msg', data);
+			OC.msg.finishedSaving('#external .msg', data);
 		});
 	}
 
-	function showDeleteButton(event) {
+	function showDeleteButton() {
 		$(this).find('img.delete_button').fadeIn(100);
 	}
 
-	function hideDeleteButton(event) {
+	function hideDeleteButton() {
 		$(this).find('img.delete_button').fadeOut(100);
 	}
 

--- a/external/lib/external.php
+++ b/external/lib/external.php
@@ -21,10 +21,12 @@
  *
  */
 
-class OC_External {
+namespace OCA\External;
+
+class External {
 
 	public static function getSites() {
-		if (($sites = json_decode(OCP\Config::getAppValue("external", "sites", ''))) != null) {
+		if (($sites = json_decode(\OCP\Config::getAppValue("external", "sites", ''))) != null) {
 			return $sites;
 		}
 

--- a/external/settings.php
+++ b/external/settings.php
@@ -1,6 +1,7 @@
 <?php
 
 OCP\User::checkAdminUser();
+OCP\JSON::checkAppEnabled('external');
 
 OCP\Util::addscript( "external", "admin" );
 

--- a/external/templates/settings.php
+++ b/external/templates/settings.php
@@ -1,10 +1,17 @@
 <form id="external">
 	<div class="section">
 		<h2><?php p($l->t('External Sites'));?></h2>
+		<p>
+			<em><?php p($l->t('Please note that some browsers will block displaying of sites via http if you are running https.')); ?></em>
+			<br>
+			<em><?php p($l->t('Furthermore please note that many sites these days disallow iframing due to security reasons.')); ?></em>
+			<br>
+			<em><?php p($l->t('We highly recommend to test the configured sites below properly.')); ?></em>
+		</p>
 		<ul class="external_sites">
 
 		<?php
-		$sites = OC_External::getSites();
+		$sites = \OCA\External\External::getSites();
 		for($i = 0; $i < sizeof($sites); $i++) {
 			print_unescaped('<li><input type="text" name="site_name[]" class="site_name" value="'.OCP\Util::sanitizeHTML($sites[$i][0]).'" placeholder="'.$l->t('Name').'" />
 			<input type="text" class="site_url" name="site_url[]"  value="'.OCP\Util::sanitizeHTML($sites[$i][1]).'"  placeholder="'.$l->t('URL').'" />


### PR DESCRIPTION
- adding OCP\JSON::checkAppEnabled('external') where needed
- in case a requested site is unknown we redirect to the default page
- fix X-Frame-Option header (addHeader method is so wrong)
- adding notes on iframe and http/https
- getting rid of usage of classpath and rename class OC_External to \OCA\External\External
- re-enabling save message
- fix javascript coding style

refs #1638 
refs https://github.com/owncloud/core/issues/9626
