### PR TITLE
[stable7] Fix zero size files on upload

### DIFF
--- a/files_locking/lib/lockingwrapper.php
+++ b/files_locking/lib/lockingwrapper.php
@@ -38,6 +38,11 @@ class LockingWrapper extends Wrapper {
 		if(is_dir($path)) {
 			return false;
 		}
+
+		// when uploading files the stat cache will contain the size
+		// zero after the is_dir() call above, so clearing it to
+		// make sure its real size will get re-read when needed
+		clearstatcache(false, $path);
 		if(!isset($this->locks[$path])) {
 			$this->locks[$path] = new Lock($path);
 		}


### PR DESCRIPTION
:warning: PR to stable7 :warning: 

When checking is_dir() whenever a file is being uploaded, the file's
size will initially be zero when requesting a lock. is_dir() will
internally populate the stat cache with that zero size, which cause
subsequent calles to file_size to return zero instead of the real size,
even after the file contents is there.

This fix clears the stat cache after the is_dir() call to make sure the
newly read values are the correct ones, not the cached ones.

Fixes https://github.com/owncloud/apps/issues/1858

Please review @icewind1991 @schiesbn @DeepDiver1975 

CC @karlitschek @craigpg as this goes to stable7
