### PR TITLE
Use a correctly initialized JobList in antivirus update

### DIFF
--- a/files_antivirus/appinfo/update.php
+++ b/files_antivirus/appinfo/update.php
@@ -15,7 +15,7 @@ if (version_compare($installedVersion, '0.5', '<')) {
 
 if (version_compare($installedVersion, '0.6', '<')) {
 	// remove the old job with old classname
-	$jobList = new \OC\BackgroundJob\JobList();
+	$jobList = \OC::$server->getJobList();
 	$jobs = $jobList->getAll();
 	foreach ($jobs as $job) {
 		$jobArg = $job->getArgument();


### PR DESCRIPTION
The JobList instance needs a DB connection argument which was missing.
Instead, this fix uses the JobList registered as server service, which
is already properly initialized.

Please review @bantu & @icewind1991 (for the `$server` stuff) and @VicDeo 
