### PR TITLE
user_saml: do not force login on neither special URLs nor CLI

### DIFF
--- a/user_saml/appinfo/app.php
+++ b/user_saml/appinfo/app.php
@@ -88,11 +88,8 @@ function shouldEnforceAuthentication()
 		return false;
 	}
 
-	$url = OCP\Util::getRequestUri();
-	$url_pieces = preg_split('/[\/?]/', $uri);
-
-	return !isset($url_pieces[0]) || !in_array(
-		$url_pieces[0],
+	$script = basename($_SERVER['SCRIPT_FILENAME']);
+	return !in_array($script,
 		array(
 			'cron.php',
 			'public.php',


### PR DESCRIPTION
When user_saml is configured to force users to log in, some URLs have to be excluded from the enforcement. These URLs are:
- `cron.php`
- `public.php`: authentication should not be required here
- `remote.php`: WebDAV clients and ownCloud sync clients will use Basic-Auth/Digest
- `status.php`

CLI works again when user_saml "force login" is set. It was showing some HTTP redirect stuff related to SAML authentication.
