### PR TITLE
user_saml: get quota from attributes

### DIFF
--- a/user_saml/settings.php
+++ b/user_saml/settings.php
@@ -23,7 +23,7 @@
 
 OC_Util::checkAdminUser();
 
-$params = array('saml_ssp_path', 'saml_sp_source', 'saml_force_saml_login', 'saml_autocreate', 'saml_update_user_data', 'saml_protected_groups', 'saml_default_group', 'saml_username_mapping', 'saml_email_mapping', 'saml_displayname_mapping', 'saml_group_mapping');
+$params = array('saml_ssp_path', 'saml_sp_source', 'saml_force_saml_login', 'saml_autocreate', 'saml_update_user_data', 'saml_protected_groups', 'saml_default_group', 'saml_username_mapping', 'saml_email_mapping', 'saml_quota_mapping', 'saml_default_quota', 'saml_displayname_mapping', 'saml_group_mapping');
 
 OCP\Util::addscript('user_saml', 'settings');
 
@@ -63,6 +63,8 @@ $tmpl->assign( 'saml_default_group', OCP\Config::getAppValue('user_saml', 'saml_
 $tmpl->assign( 'saml_username_mapping', OCP\Config::getAppValue('user_saml', 'saml_username_mapping', 'uid'));
 $tmpl->assign( 'saml_email_mapping', OCP\Config::getAppValue('user_saml', 'saml_email_mapping', 'mail'));
 $tmpl->assign( 'saml_displayname_mapping', OCP\Config::getAppValue('user_saml', 'saml_displayname_mapping', 'displayName'));
+$tmpl->assign( 'saml_quota_mapping', OCP\Config::getAppValue('user_saml', 'saml_quota_mapping', ''));
+$tmpl->assign( 'saml_default_quota', OCP\Config::getAppValue('user_saml', 'saml_default_quota', ''));
 $tmpl->assign( 'saml_group_mapping', OCP\Config::getAppValue('user_saml', 'saml_group_mapping', ''));
 
 return $tmpl->fetchPage();

--- a/user_saml/templates/settings.php
+++ b/user_saml/templates/settings.php
@@ -21,6 +21,8 @@
 		<p><label for="saml_username_mapping"><?php p($l->t('Username'));?></label><input type="text" id="saml_username_mapping" name="saml_username_mapping" value="<?php p($_['saml_username_mapping']); ?>" /></p>
 		<p><label for="saml_email_mapping"><?php p($l->t('Email'));?></label><input type="text" id="saml_email_mapping" name="saml_email_mapping" value="<?php p($_['saml_email_mapping']); ?>" /></p>
 		<p><label for="saml_displayname_mapping"><?php p($l->t('DisplayName'));?></label><input type="text" id="saml_displayname_mapping" name="saml_displayname_mapping" value="<?php p($_['saml_displayname_mapping']); ?>" /></p>
+		<p><label for="saml_quota_mapping"><?php p($l->t('Quota'));?></label><input type="text" id="saml_quota_mapping" name="saml_quota_mapping" value="<?php p($_['saml_quota_mapping']); ?>" /></p>
+        <p><label for="saml_default_quota"><?php p($l->t('Quota Default'));?></label><input type="text" id="saml_default_quota" name="saml_default_quota" value="<?php p($_['saml_default_quota']); ?>" title="<?php echo $l->t('in bytes');?>" /></p>
 		<p><label for="saml_group_mapping"><?php p($l->t('Group'));?></label><input type="text" id="saml_group_mapping" name="saml_group_mapping" value="<?php p($_['saml_group_mapping']); ?>" /></p>
 	</fieldset>
 	<input type="hidden" name="requesttoken" value="<?php echo $_['requesttoken'] ?>" id="requesttoken">

--- a/user_saml/user_saml.php
+++ b/user_saml/user_saml.php
@@ -34,6 +34,8 @@ class OC_USER_SAML extends OC_User_Backend {
 	public $usernameMapping;
 	public $mailMapping;
 	public $displayNameMapping;
+	public $quotaMapping;
+	public $defaultQuota;
 	public $groupMapping;
 	public $auth;
 
@@ -49,6 +51,8 @@ class OC_USER_SAML extends OC_User_Backend {
 		$this->usernameMapping = explode (',', preg_replace('/\s+/', '', OCP\Config::getAppValue('user_saml', 'saml_username_mapping', '')));
 		$this->mailMapping = explode (',', preg_replace('/\s+/', '', OCP\Config::getAppValue('user_saml', 'saml_email_mapping', '')));
 		$this->displayNameMapping = explode (',', preg_replace('/\s+/', '', OCP\Config::getAppValue('user_saml', 'saml_displayname_mapping', '')));
+		$this->quotaMapping = explode (',', preg_replace('/\s+/', '', OCP\Config::getAppValue('user_saml', 'saml_quota_mapping', '')));
+		$this->defaultQuota = OCP\Config::getAppValue('user_saml', 'saml_default_quota', '');
 		$this->groupMapping = explode (',', preg_replace('/\s+/', '', OCP\Config::getAppValue('user_saml', 'saml_group_mapping', '')));
 
 		if (!empty($this->sspPath) && !empty($this->spSource)) {


### PR DESCRIPTION
This PR allows you to set user quotas using user_saml.
- Adds a new setting to configure a mapping for the quota attribute
- Lets you set a default quota for cases when the mapping is not configured or the attribute is empty for the current user

It is heavily inspired on user_ldap quota settings.
