### PR TITLE
Skip job execution if app is disabled

### DIFF
--- a/files_antivirus/lib/backgroundscanner.php
+++ b/files_antivirus/lib/backgroundscanner.php
@@ -10,6 +10,10 @@ namespace OCA\Files_Antivirus;
 
 class BackgroundScanner {
 	public static function check() {
+		if (!\OCP\App::isEnabled('files_antivirus')){
+			return;
+		}
+		
 		// get mimetype code for directory
 		$query = \OCP\DB::prepare('SELECT `id` FROM `*PREFIX*mimetypes` WHERE `mimetype` = ?');
 		$result = $query->execute(array('httpd/unix-directory'));


### PR DESCRIPTION
Some tasks are scheduled to be executed later. We don't need them when the app is disabled.
