### PR TITLE
Save the locked handle in obtainWriteLock

### DIFF
--- a/files_locking/lib/lock.php
+++ b/files_locking/lib/lock.php
@@ -157,6 +157,7 @@ class Lock {
 			\OC_Log::write('lock', sprintf('FAIL: Write lock failed due to timeout on %s', $this->path), \OC_Log::DEBUG);
 			return false;
 		}
+		$this->handle = $handle;
 		\OC_Log::write('lock', sprintf('PASS: Write lock succeeded on %s', $this->path), \OC_Log::DEBUG);
 
 		return true;


### PR DESCRIPTION
Prevents the handle from going out of scope and the lock automatically being freed

cc @th3fallen @DeepDiver1975 
