### PR TITLE
Order BY is not compatible with all DBs

### DIFF
--- a/files_antivirus/appinfo/preupdate.php
+++ b/files_antivirus/appinfo/preupdate.php
@@ -5,7 +5,7 @@ if (version_compare($installedVersion, '0.6', '<')) {
 	$query = OC_DB::prepare( 'SELECT COUNT(*) AS `count`, `fileid` FROM `*PREFIX*files_antivirus` GROUP BY `fileid` HAVING COUNT(*) > 1' );
 	$result = $query->execute();
 	while( $row = $result->fetchRow()) {
-		$deleteQuery = OC_DB::prepare('DELETE FROM `*PREFIX*files_antivirus` WHERE `fileid` = ? ORDER BY `check_time` ASC', $row['count']-1);
+		$deleteQuery = OC_DB::prepare('DELETE FROM `*PREFIX*files_antivirus` WHERE `fileid` = ?');
 		$deleteQuery->execute(array($row['fileid']));
 	}
 }


### PR DESCRIPTION
This prevents updates to a newer version when running on a DB that does not support ORDER BY in delete queries.

@karlitschek Requires a backport to stable7.