### PR TITLE
user_saml: Fix slo initiated by owncloud

### DIFF
--- a/user_saml/lib/hooks.php
+++ b/user_saml/lib/hooks.php
@@ -68,9 +68,6 @@ class OC_USER_SAML_Hooks {
 		$samlBackend = new OC_USER_SAML();
 		if ($samlBackend->auth->isAuthenticated()) {
 			OC_Log::write('saml', 'Executing SAML logout', OC_Log::DEBUG);
-			unset($_COOKIE["SimpleSAMLAuthToken"]);
-			setcookie('SimpleSAMLAuthToken', '', time()-3600, \OC::$WEBROOT);
-			setcookie('SimpleSAMLAuthToken', '', time()-3600, \OC::$WEBROOT . '/');
 			$samlBackend->auth->logout();
 		}
 		return true;


### PR DESCRIPTION
SimpleSAML need SimpleSAMLAuthToken cookie to proceed a correct logout

When you remove the SimpleSAMLAuthToken cookie before a SimpleSAML logout. SimpleSAML traceback with this error : "SimpleSAML_Error_NoState: NOSTATE" during the slo.
To fix this issue we need to keep this cookie and the SimpleSAML's logout method will remove it.
