### PR TITLE
Make sharing easier

### DIFF
--- a/user_external/lib/imap.php
+++ b/user_external/lib/imap.php
@@ -42,7 +42,7 @@ class OC_User_IMAP extends \OCA\user_external\Base {
 			OCP\Util::writeLog('user_external', 'ERROR: PHP imap extension is not installed', OCP\Util::ERROR);
 			return false;
 		}
-		$mbox = @imap_open($this->mailbox, $uid, $password, OP_HALFOPEN);
+		$mbox = @imap_open($this->mailbox, $uid, $password, OP_HALFOPEN, 1);
 		imap_errors();
 		imap_alerts();
 		if($mbox !== FALSE) {


### PR DESCRIPTION
Now Users have just to enter a part of the name. e.g. 'do' for 'John Doe'.
see also: owncloud/core#11256