### PR TITLE
[external app] Move style.css registration

### DIFF
--- a/external/appinfo/app.php
+++ b/external/appinfo/app.php
@@ -23,7 +23,6 @@
 
 use OCA\External\External;
 
-OCP\Util::addStyle( 'external', 'style');
 OCP\App::registerAdmin('external', 'settings');
 
 $sites = External::getSites();

--- a/external/index.php
+++ b/external/index.php
@@ -26,6 +26,7 @@ use OCA\External\External;
 
 OCP\JSON::checkAppEnabled('external');
 OCP\User::checkLoggedIn();
+OCP\Util::addStyle( 'external', 'style');
 
 $id = isset($_GET['id']) ? (int)$_GET['id'] : 1;
 


### PR DESCRIPTION
Move style.css registration from app.php to index.php in "external" app.

**Fixes:**
- [external] ownCloud theming error (with solution!) #2026

The stylesheet ../apps/external/css/style.css is integrated in the wrong place, so this stylesheet loads independent of the fact, if external app is active or not.
This fixes this issue and only loads style.css, if external app is active

**Advantages:**
- reduces unneccessary traffic load
- allows theming of owncloud header depending on the state, if external app is active
- behaves in this point now as other apps already do