### PR TITLE
don't go to $retval != 0 in case of NT_STATUS_BAD_NETWORK_NAME

### DIFF
--- a/user_external/lib/smb.php
+++ b/user_external/lib/smb.php
@@ -54,6 +54,9 @@ class OC_User_SMB extends \OCA\user_external\Base{
 		} else if (strpos($lastline, self::LOGINERROR) !== false) {
 			//normal login error
 			return false;
+		} else if (strpos($lastline, 'NT_STATUS_BAD_NETWORK_NAME') !== false) {
+			//login on minor error
+			goto login;
 		} else if ($retval != 0) {
 			//some other error
 			OCP\Util::writeLog(
@@ -62,6 +65,7 @@ class OC_User_SMB extends \OCA\user_external\Base{
 			);
 			return false;
 		} else {
+			login:
 			$this->storeUser($uid);
 			return $uid;
 		}


### PR DESCRIPTION
NT_STATUS_BAD_NETWORK_NAME is only a minor error which should not prevent login

Fixes #1974 