### PR TITLE
[stable6] Verify if path exists before processing

### DIFF
--- a/gallery/ajax/gallery.php
+++ b/gallery/ajax/gallery.php
@@ -19,6 +19,9 @@ if ($owner !== OCP\User::getUser()) {
 	list($shareId, , $gallery) = explode('/', $gallery, 3);
 	if (OCP\Share::getItemSharedWith('file', $shareId)) {
 		$sharedGallery = $ownerView->getPath($shareId);
+		if($sharedGallery === null) {
+			exit();
+		}
 		if ($gallery) {
 			$gallery = $sharedGallery . '/' . $gallery;
 		} else {

--- a/gallery/ajax/getimages.php
+++ b/gallery/ajax/getimages.php
@@ -27,7 +27,9 @@ if (isset($_GET['token'])) {
 
 		// The token defines the target directory (security reasons)
 		$path = \OC\Files\Filesystem::getPath($linkItem['file_source']);
-
+		if($path === null) {
+			exit();
+		}
 		$view = new \OC\Files\View(\OC\Files\Filesystem::getView()->getAbsolutePath($path));
 		$images = $view->searchByMime('image');
 

--- a/gallery/ajax/image.php
+++ b/gallery/ajax/image.php
@@ -52,6 +52,9 @@ $ownerView = new \OC\Files\View('/' . $owner . '/files');
 if (is_array($linkItem) && isset($linkItem['uid_owner'])) {
 	// prepend path to share
 	$path = $ownerView->getPath($linkItem['file_source']);
+	if($path === null) {
+		exit();
+	}
 	$img = $path.'/'.$img;
 }
 

--- a/gallery/ajax/thumbnail.php
+++ b/gallery/ajax/thumbnail.php
@@ -51,6 +51,9 @@ if (is_array($linkItem) && isset($linkItem['uid_owner'])) {
 	// prepend path to share
 	$ownerView = new \OC\Files\View('/' . $owner . '/files');
 	$path = $ownerView->getPath($linkItem['file_source']);
+	if($path === null) {
+		exit();
+	}
 	$img = $path . '/' . $img;
 }
 


### PR DESCRIPTION
We need to verify if the specified path exists to prevent errors. To test this please ensure that in all legitim cases the public preview (i.e. the one you see when you have public shared galleries) does still work.

While exit() is here not the cleanest solution this is also what is used in other parts of the AJAX gallery code for error handling and I consider this thus a feasible solution for now.

@icewind1991 @PVince81 I'd appreciate if you could review these.