### PR TITLE
IMAP login can be restricted to a specific domain name.

### DIFF
--- a/user_external/README.md
+++ b/user_external/README.md
@@ -66,12 +66,16 @@ Add the following to your `config.php`:
         array(
             'class' => 'OC_User_IMAP',
             'arguments' => array(
-                '{127.0.0.1:143/imap/readonly}',
+                '{127.0.0.1:143/imap/readonly}', 'example.com'
             ),
         ),
     ),
 
 This connects to the IMAP server on IP `127.0.0.1`, in readonly mode.
+If a domain name (e.g. example.com) is specified, then this makes sure that 
+only users from this domain will be allowed to login. After successfull
+login the domain part will be striped and the rest used as username in
+ownCloud. e.g. 'username@example.com' will be 'username' in ownCloud.
 
 Read the [imap_open][0] PHP manual page to learn more about the allowed
 parameters.


### PR DESCRIPTION
I have an instance of ownCloud which is used only for one domain and I wanted to make the users able to login via IMAP only with this specific domain name. 
If no domain name is given in the configuration file, then the behaviour is the same as before. 

This closes #1708.
