### PR TITLE
[stable8.2] Use public webdav link for video preview

### DIFF
--- a/files_videoviewer/js/viewer.js
+++ b/files_videoviewer/js/viewer.js
@@ -56,7 +56,9 @@ var videoViewer = {
 		videoViewer.dir = data.dir;
 		if ($('#isPublic').length){
 			// No seek for public videos atm, sorry
-			videoViewer.location = data.fileList.getDownloadUrl(file, videoViewer.dir);
+			var token = $('#sharingToken').val();
+			videoViewer.location = window.location.protocol + '//' + token + '@' + window.location.host +
+				OC.linkTo('', 'public.php/webdav/' + OC.joinPaths(videoViewer.dir, file));
 		} else {
 			videoViewer.location = OC.linkToRemote('webdav') + OC.joinPaths(videoViewer.dir, file);
 		}


### PR DESCRIPTION
:warning: doesn't work :warning: 

Tentative to make the video viewer use the public link.
However it looks like the video player component doesn't send the authentication header.

Needs further research...

@VicDeo @brandneb