### PR TITLE
Allow extra images for external app icons to live in the theme.

### DIFF
--- a/external/settings.php
+++ b/external/settings.php
@@ -10,7 +10,20 @@ $tmpl = new OCP\Template( 'external', 'settings');
 $images = glob(\OC_App::getAppPath('external') . '/img/*.*');
 $theme = \OC::$server->getSystemConfig()->getValue('theme', '');
 if (file_exists(\OC::$SERVERROOT . "/themes/$theme/apps/external/img/")) {
-	$images = array_merge($images, glob(\OC::$SERVERROOT . "/themes/$theme/apps/external/img/*.*"));
+	$theme_images = glob(\OC::$SERVERROOT . "/themes/$theme/apps/external/img/*.*");
+	$unique_images = array();
+	foreach ($theme_images as $theme_image) {
+		$unique_flag = true;
+		foreach ($images as $image) {
+			if (basename($image) == basename($theme_image)) {
+				$unique_flag = false;
+				break;
+			}
+		}
+		if ($unique_flag) {
+			$images[] = $theme_image;
+		}
+	}
 }
 
 $tmpl->assign('images', $images);

--- a/external/settings.php
+++ b/external/settings.php
@@ -11,7 +11,6 @@ $images = glob(\OC_App::getAppPath('external') . '/img/*.*');
 $theme = \OC::$server->getSystemConfig()->getValue('theme', '');
 if (file_exists(\OC::$SERVERROOT . "/themes/$theme/apps/external/img/")) {
 	$theme_images = glob(\OC::$SERVERROOT . "/themes/$theme/apps/external/img/*.*");
-	$unique_images = array();
 	foreach ($theme_images as $theme_image) {
 		$unique_flag = true;
 		foreach ($images as $image) {

--- a/external/settings.php
+++ b/external/settings.php
@@ -7,6 +7,12 @@ OCP\Util::addscript( "external", "admin" );
 
 $tmpl = new OCP\Template( 'external', 'settings');
 
-$tmpl->assign('images', glob(\OC_App::getAppPath('external') . '/img/*.*'));
+$images = glob(\OC_App::getAppPath('external') . '/img/*.*');
+$theme = \OC_Util::getTheme();
+if (file_exists(\OC::$SERVERROOT . "/themes/$theme/apps/external/img/")) {
+	$images = array_merge($images, glob(\OC::$SERVERROOT . "/themes/$theme/apps/external/img/*.*"));
+}
+
+$tmpl->assign('images', $images);
 
 return $tmpl->fetchPage();

--- a/external/settings.php
+++ b/external/settings.php
@@ -8,7 +8,7 @@ OCP\Util::addscript( "external", "admin" );
 $tmpl = new OCP\Template( 'external', 'settings');
 
 $images = glob(\OC_App::getAppPath('external') . '/img/*.*');
-$theme = \OC_Util::getTheme();
+$theme = \OC::$server->getSystemConfig()->getValue('theme', '');
 if (file_exists(\OC::$SERVERROOT . "/themes/$theme/apps/external/img/")) {
 	$images = array_merge($images, glob(\OC::$SERVERROOT . "/themes/$theme/apps/external/img/*.*"));
 }


### PR DESCRIPTION
Allows extra icons for the external app to be in the theme directory. Assumes a location of /themes/selected_theme_in_config.php/apps/external/img/ for image files to match standard apps location. Tested in 8.1.3 and 8.1.4.