### PR TITLE
Restructure Samba auth

### DIFF
--- a/user_external/lib/smb.php
+++ b/user_external/lib/smb.php
@@ -43,7 +43,7 @@ class OC_User_SMB extends \OCA\user_external\Base{
 		$result=array();
 		$command=self::SMBCLIENT.' //'.$this->host.'/dummy -U '.$uidEscaped.'%'.$password;
 		$lastline = exec($command, $output, $retval);
-		if ($retval == 0 || strpos($lastline, 'NT_STATUS_BAD_NETWORK_NAME') !== false) {
+		if ($retval === 0 || strpos($lastline, 'NT_STATUS_BAD_NETWORK_NAME') !== false) {
 			// success, or a minor error
 			$this->storeUser($uid);
 			return $uid;

--- a/user_external/lib/smb.php
+++ b/user_external/lib/smb.php
@@ -50,7 +50,6 @@ class OC_User_SMB extends \OCA\user_external\Base{
 		} else if (strpos($lastline, 'NT_STATUS_LOGON_FAILURE') !== false) {
 			// bad password
 			return false;
-		}
 		} else if ($retval === 127) {
 			// command not found
 			OCP\Util::writeLog('user_external', 'ERROR: smbclient executable missing', OCP\Util::ERROR);


### PR DESCRIPTION
Some Samba errors like NT_ERROR_ACCESS_DENIED are hid with the `-L` flag. Default to failing instead of success.

By default Samba allows guest login. By denying guests access to the dummy share, you can keep ownCloud from creating non-existent users. Before this change, if a user that did not exist in Samba was entered login would succeed.

```
[dummy]
    guest ok = no
```