### PR TITLE
backport of PR #2157

### DIFF
--- a/user_external/lib/webdavauth.php
+++ b/user_external/lib/webdavauth.php
@@ -14,7 +14,7 @@ class WebDavAuth extends Base {
 
 	public function __construct($webDavAuthUrl) {
 		parent::__construct($webDavAuthUrl);
-		$this->$webDavAuthUrl =$webDavAuthUrl;
+		$this->webDavAuthUrl =$webDavAuthUrl;
 	}
 
 	/**


### PR DESCRIPTION
Leaving "$webDavAuthUrl" in constructor, leads to a non-working class
ref #2157