### PR TITLE
user_saml: [fix] error on autocreating user

### DIFF
--- a/user_saml/user_saml.php
+++ b/user_saml/user_saml.php
@@ -101,7 +101,7 @@ class OC_USER_SAML extends OC_User_Backend {
                         OCP\Util::writeLog('saml','Invalid username "'.$uid.'", allowed chars "a-zA-Z0-9" and "_.@-" ',OCP\Util::DEBUG);
                         return false;
                 } else {
-                        $random_password = \OC_Util::generateRandomBytes(64);
+                        $random_password = OCP\Util::generateRandomBytes(64);
                         OCP\Util::writeLog('saml','Creating new user: '.$uid, OCP\Util::DEBUG);
                         \OC::$server->getUserManager()->createUser($uid, $random_password);
                         return $uid;


### PR DESCRIPTION
Trying to create new user on saml-login procedure, owncloud crashes with error below:
`Error: Call to undefined method OC_Util::generateRandomBytes() at /srv/owncloud/apps/user_saml/user_saml.php#104`