### PR TITLE
Updated utils.js to hide saml logo after ldap login.

### DIFF
--- a/user_saml/js/utils.js
+++ b/user_saml/js/utils.js
@@ -25,6 +25,8 @@ $(document).ready(function(){
         $('#remember_login').hide();
         $('#remember_login+label').hide();
         $('#submit').hide();
+    } else if (!$('#user').is(":visible")) {
+        $('#login-saml').hide();
     }
 
     $('#user').change( function() {


### PR DESCRIPTION
In my organisation we use owncloud-LDAP authentication since long time(2 year). according to time change we need to adopt new technologies and secure method so we recently we decide to enable ADFS-SSO authentication using SAML. we configured it correctly. and it is working fine.

But issue happen when we enable both authentication LDAP + ADFS-SAML simultaneously. because organization some user want to use LDAP some prefer ADFS-SSO. and also to share file with those new user who have never signed-up or sign-in  yet. we can't  remove LDAP integration because we want to fetch user's list from Active Directory to share files with them.Note: In scenario of ADFS-SSO once user will signup his/her entry created inside oc_users table and then we can share file with them. in this scenario if person use LDAP auth first time to sign-in SAML-login logo don't hide. This one: 
![image](https://cloud.githubusercontent.com/assets/6395501/14446903/e315f23c-0095-11e6-9f65-d064779da328.png)

it hovers on home screen after login. so i proposed this pull request to solve this issue.