### PR TITLE
enhance with docu/web/bug/repo sections to encourage their use

### DIFF
--- a/apptemplate/appinfo/info.xml
+++ b/apptemplate/appinfo/info.xml
@@ -7,4 +7,17 @@
 	<licence>AGPL</licence>
 	<author>Frank Karlitschek</author>
 	<requiremin>4</requiremin>
+	
+	<documentation>
+            <user>https://doc.owncloud.org</user>
+            <admin>https://doc.owncloud.org</admin>
+            <developer>https://doc.owncloud.org</developer>
+        </documentation>
+        
+        <website>https://github.com/owncloud/theapp</website>
+
+        <bugs>https://github.com/owncloud/theapp/issues</bugs>
+
+        <repository type="git">https://github.com/owncloud/theapp.git</repository>
+
 </info>


### PR DESCRIPTION
A developer using this template will probably find it easier to delete these sections than to add them. 
And I would even declare them required, as they always (should) exist (at least as stubs) to simplify the life for others to contribute.

Furthermore I added the `<developer>https://doc.owncloud.org</developer>` section as I see no reason for it to be omitted here. (and it can easily be linked to the github `README.md` file if this is the place where the developer want to store these infos)

Having this information at this central place for every app would make the life much easier as often the documentation already exists, it is just quite difficult to find it (if the owncloud pages and the oc github repositories are not your daily business).

(see related changes to this file as well: https://github.com/owncloud/documentation/edit/master/developer_manual/app/info.rst)
