### PR TITLE
Remove nonsensical header in external

### DIFF
--- a/external/index.php
+++ b/external/index.php
@@ -36,8 +36,6 @@ if (sizeof($sites) >= $id) {
 	OCP\App::setActiveNavigationEntry('external_index' . $id);
 
 	$tmpl = new OCP\Template('external', 'frame', 'user');
-	//overwrite x-frame-options
-	header('X-Frame-Options: ALLOW-FROM *');
 
 	$tmpl->assign('url', $url);
 	$tmpl->printPage();


### PR DESCRIPTION
X-Frames-Option & Co need to be set by the embeddee, not the embedder