### PR TITLE
[regression] Fix external sites form

### DIFF
--- a/external/js/admin.js
+++ b/external/js/admin.js
@@ -22,7 +22,7 @@ $(document).ready(function(){
 	}
 
 	function saveSites() {
-		var post = $('#external').serialize();
+		var post = $('#external form').serialize();
 		OC.msg.startSaving('#external .msg');
 		$.post( OC.filePath('external','ajax','setsites.php') , post, function(data) {
 			OC.msg.finishedSaving('#external .msg', data);

--- a/external/templates/settings.php
+++ b/external/templates/settings.php
@@ -1,13 +1,12 @@
-<form id="external">
-	<div class="section">
-		<h2><?php p($l->t('External Sites'));?></h2>
-		<p>
-			<em><?php p($l->t('Please note that some browsers will block displaying of sites via http if you are running https.')); ?></em>
-			<br>
-			<em><?php p($l->t('Furthermore please note that many sites these days disallow iframing due to security reasons.')); ?></em>
-			<br>
-			<em><?php p($l->t('We highly recommend to test the configured sites below properly.')); ?></em>
-		</p>
+<form class="section">
+	<h2><?php p($l->t('External Sites'));?></h2>
+	<p>
+		<em><?php p($l->t('Please note that some browsers will block displaying of sites via http if you are running https.')); ?></em>
+		<br>
+		<em><?php p($l->t('Furthermore please note that many sites these days disallow iframing due to security reasons.')); ?></em>
+		<br>
+		<em><?php p($l->t('We highly recommend to test the configured sites below properly.')); ?></em>
+	</p>
 		<ul class="external_sites">
 
 		<?php
@@ -53,7 +52,6 @@
 
 		</ul>
 
-        <input type="button" id="add_external_site" value="<?php p($l->t("Add")); ?>" />
-		<span class="msg"></span>
-	</div>
+	<input type="button" id="add_external_site" value="<?php p($l->t("Add")); ?>" />
+	<span class="msg"></span>
 </form>


### PR DESCRIPTION
Some changes in the admin page structure regarding section names is causing a conflict with the form name.

Before this fix: when adding a site and refreshing the page, it was gone.
After this fix: site properly added

Note: the app is called "External sites"

Please review @DeepDiver1975 @PhilippSchaffrath @felixheidecke
