### PR TITLE
Add new site target option to External Site options

### DIFF
--- a/external/ajax/setsites.php
+++ b/external/ajax/setsites.php
@@ -14,7 +14,16 @@ OCP\JSON::callCheck();
 $sites = array();
 for ($i = 0; $i < sizeof($_POST['site_name']); $i++) {
 	if (!empty($_POST['site_name'][$i]) && !empty($_POST['site_url'][$i])) {
-		array_push($sites, array(strip_tags($_POST['site_name'][$i]), strip_tags($_POST['site_url'][$i]), strip_tags($_POST['site_icon'][$i])));
+		// make sure site_target is a safe link target type
+		if (!in_array($_POST['site_target'][$i], $_['targets'])) {
+		    throw new Exception('Invalid site target, must be one of: ' . implode(", ", $_['targets']));
+		}
+		array_push($sites, array(
+			strip_tags($_POST['site_name'][$i]),
+			strip_tags($_POST['site_url'][$i]),
+			strip_tags($_POST['site_icon'][$i]),
+			strip_tags($_POST['site_target'][$i]),
+		));
 	}
 }
 

--- a/external/ajax/setsites.php
+++ b/external/ajax/setsites.php
@@ -11,12 +11,14 @@ OCP\JSON::checkAppEnabled('external');
 OCP\User::checkAdminUser();
 OCP\JSON::callCheck();
 
+$valid_targets = array('_blank', '_top', '_self');  // TODO: import this from external/settings.php
+
 $sites = array();
 for ($i = 0; $i < sizeof($_POST['site_name']); $i++) {
 	if (!empty($_POST['site_name'][$i]) && !empty($_POST['site_url'][$i])) {
 		// make sure site_target is a safe link target type
-		if (!in_array($_POST['site_target'][$i], $_['targets'])) {
-		    throw new Exception('Invalid site target, must be one of: ' . implode(", ", $_['targets']));
+		if (!in_array($_POST['site_target'][$i], $valid_targets)) {
+		    throw new Exception('Invalid site target, must be one of: ' . implode(", ", $valid_targets));
 		}
 		array_push($sites, array(
 			strip_tags($_POST['site_name'][$i]),

--- a/external/appinfo/app.php
+++ b/external/appinfo/app.php
@@ -37,8 +37,8 @@ if (!empty($sites)) {
 				// if link is iframed, change href to point to internal url /external/<site_id>
 				$href = $urlGenerator->linkToRoute('external_index', ['id'=> $site_id]);
 			}
-			$icon_name = empty($sites[$i][2]) ? 'external.svg' : $sites[$i][2]
-			$icon = $urlGenerator->imagePath('external', $icon_name)
+			$icon_name = empty($sites[$i][2]) ? 'external.svg' : $sites[$i][2];
+			$icon = $urlGenerator->imagePath('external', $icon_name);
 			$name = $sites[$i][0];
 			$target = $sites[$i][3];
 			return [

--- a/external/appinfo/app.php
+++ b/external/appinfo/app.php
@@ -31,12 +31,17 @@ if (!empty($sites)) {
 	$navigationManager = \OC::$server->getNavigationManager();
 	for ($i = 0; $i < sizeof($sites); $i++) {
 		$navigationEntry = function () use ($i, $urlGenerator, $sites) {
+			$href = $sites[$i][1];
+			if ($sites[$i][3] == '_self') {
+				$href = $urlGenerator->linkToRoute('external_index', ['id'=> $i + 1]);
+			}
 			return [
 				'id'    => 'external_index' . ($i + 1),
 				'order' => 80 + $i,
-				'href' => $urlGenerator->linkToRoute('external_index', ['id'=> $i + 1]),
+				'href' => $href,
 				'icon' => $urlGenerator->imagePath('external', !empty($sites[$i][2]) ? $sites[$i][2] : 'external.svg'),
 				'name' => $sites[$i][0],
+				'target' => $sites[$i][3],
 			];
 		};
 		$navigationManager->add($navigationEntry);

--- a/external/appinfo/app.php
+++ b/external/appinfo/app.php
@@ -31,17 +31,23 @@ if (!empty($sites)) {
 	$navigationManager = \OC::$server->getNavigationManager();
 	for ($i = 0; $i < sizeof($sites); $i++) {
 		$navigationEntry = function () use ($i, $urlGenerator, $sites) {
+			$site_id = ($i + 1);
 			$href = $sites[$i][1];
-			if ($sites[$i][3] == '_self') {
-				$href = $urlGenerator->linkToRoute('external_index', ['id'=> $i + 1]);
+			if ($target == '_self') {
+				// if link is iframed, change href to point to internal url /external/<site_id>
+				$href = $urlGenerator->linkToRoute('external_index', ['id'=> $site_id]);
 			}
+			$icon_name = empty($sites[$i][2]) ? 'external.svg' : $sites[$i][2]
+			$icon = $urlGenerator->imagePath('external', $icon_name)
+			$name = $sites[$i][0];
+			$target = $sites[$i][3];
 			return [
-				'id'    => 'external_index' . ($i + 1),
-				'order' => 80 + $i,
-				'href' => $href,
-				'icon' => $urlGenerator->imagePath('external', !empty($sites[$i][2]) ? $sites[$i][2] : 'external.svg'),
-				'name' => $sites[$i][0],
-				'target' => $sites[$i][3],
+				'id'     => 'external_index' . $site_id,
+				'order'  => 80 + $i,
+				'href'   => $href,
+				'icon'   => $icon,
+				'name'   => $name,
+				'target' => $target,
 			];
 		};
 		$navigationManager->add($navigationEntry);

--- a/external/settings.php
+++ b/external/settings.php
@@ -27,4 +27,11 @@ if (file_exists(\OC::$SERVERROOT . "/themes/$theme/apps/external/img/")) {
 
 $tmpl->assign('images', $images);
 
+// _blank opens link in a new window/tab
+// _top replaces the current owncloud window with link
+// _self opens link in the ownCloud iframe
+$tmpl->assign('targets', array('_blank', '_top', '_self'));
+$tmpl->assign('targets_desc', array('New Window', 'Replace Current Window', 'Inside OwnCloud Frame'));
+
+
 return $tmpl->fetchPage();

--- a/external/settings.php
+++ b/external/settings.php
@@ -26,10 +26,6 @@ if (file_exists(\OC::$SERVERROOT . "/themes/$theme/apps/external/img/")) {
 }
 
 $tmpl->assign('images', $images);
-
-// _blank opens link in a new window/tab
-// _top replaces the current owncloud window with link
-// _self opens link in the ownCloud iframe
 $tmpl->assign('targets', array('_blank', '_top', '_self'));
 $tmpl->assign('targets_desc', array('New Window', 'Replace Current Window', 'Inside OwnCloud Frame'));
 

--- a/external/settings.php
+++ b/external/settings.php
@@ -26,8 +26,14 @@ if (file_exists(\OC::$SERVERROOT . "/themes/$theme/apps/external/img/")) {
 }
 
 $tmpl->assign('images', $images);
-$tmpl->assign('targets', array('_blank', '_top', '_self'));
-$tmpl->assign('targets_desc', array('New Window', 'Replace Current Window', 'Inside OwnCloud Frame'));
+
+// _blank opens link in a new window/tab
+// _top replaces the current owncloud window with link
+// _self opens link in the ownCloud iframe
+$targets = array('_blank', '_top', '_self');
+$targets_desc = array('New Window', 'Replace Current Window', 'Inside OwnCloud Frame');
+$tmpl->assign('targets', $targets);
+$tmpl->assign('targets_desc', $targets_desc);
 
 
 return $tmpl->fetchPage();

--- a/external/settings.php
+++ b/external/settings.php
@@ -27,9 +27,6 @@ if (file_exists(\OC::$SERVERROOT . "/themes/$theme/apps/external/img/")) {
 
 $tmpl->assign('images', $images);
 
-// _blank opens link in a new window/tab
-// _top replaces the current owncloud window with link
-// _self opens link in the ownCloud iframe
 $targets = array('_blank', '_top', '_self');
 $targets_desc = array('New Window', 'Replace Current Window', 'Inside OwnCloud Frame');
 $tmpl->assign('targets', $targets);

--- a/external/templates/settings.php
+++ b/external/templates/settings.php
@@ -33,9 +33,9 @@
 			print_unescaped('</select><select class="site_target" name="site_target[]">');
 			foreach($_['targets'] as $idx=>$target) {
 				if ($target == $sites[$i][3]) {
-					print_unescaped('<option value="'.$target.'" selected>'.$_['target_desc'][$idx].'</option>');
+					print_unescaped('<option value="'.$target.'" selected>'.$_['targets_desc'][$idx].'</option>');
 				} else {
-					print_unescaped('<option value="'.$target.'">'.$_['target_desc'][$idx].'</option>');
+					print_unescaped('<option value="'.$target.'">'.$_['targets_desc'][$idx].'</option>');
 				}
 			}
 			print_unescaped('</select><img class="svg action delete_button" src="'.OCP\image_path("", "actions/delete.svg") .'" title="'.$l->t("Remove site").'" />

--- a/external/templates/settings.php
+++ b/external/templates/settings.php
@@ -38,7 +38,8 @@
 					print_unescaped('<option value="'.$target.'">'.$_['targets_desc'][$idx].'</option>');
 				}
 			}
-			print_unescaped('</select><img class="svg action delete_button" src="'.OCP\image_path("", "actions/delete.svg") .'" title="'.$l->t("Remove site").'" />
+			print_unescaped('</select>
+			<img class="svg action delete_button" src="'.OCP\image_path("", "actions/delete.svg") .'" title="'.$l->t("Remove site").'" />
 			</li>');
 		}
 		if(sizeof($sites) === 0) {

--- a/external/templates/settings.php
+++ b/external/templates/settings.php
@@ -30,8 +30,15 @@
 			} else {
 				print_unescaped('<option value="">'.$l->t('Select an icon').'</option>');
 			}
-			print_unescaped('</select>
-			<img class="svg action delete_button" src="'.OCP\image_path("", "actions/delete.svg") .'" title="'.$l->t("Remove site").'" />
+			print_unescaped('</select><select class="site_target" name="site_target[]">');
+			foreach($_['targets'] as $idx=>$target) {
+				if ($target == $sites[$i][3]) {
+					print_unescaped('<option value="'.$target.'" selected>'.$_['target_desc'][$idx].'</option>');
+				} else {
+					print_unescaped('<option value="'.$target.'">'.$_['target_desc'][$idx].'</option>');
+				}
+			}
+			print_unescaped('</select><img class="svg action delete_button" src="'.OCP\image_path("", "actions/delete.svg") .'" title="'.$l->t("Remove site").'" />
 			</li>');
 		}
 		if(sizeof($sites) === 0) {


### PR DESCRIPTION
This PR adds a `site_target` option which lets users specify whether an External Site is framed by owncloud, replaces the current window, or opens in a separate window.

Picking up stale PR: https://github.com/owncloud/apps/pull/2216

Fixes:
 - prevents possible XSS by validating targets against allowed list

Adds:
 - human-readable descriptions on target options
 - documentation explaining how to add an external site that blocks iframing: https://github.com/owncloud/documentation/pull/3384

Questions:
  How can I import the value `$targets` defined in `external/settings.php` into `external/ajax/setsites.php`?
  Is there some helper function like `getAppConfig().getKey('targets')` or `getAppSettings('external')['targets']`?